### PR TITLE
Support for Intel Compiler and Math Kernel Library

### DIFF
--- a/boost.py
+++ b/boost.py
@@ -55,6 +55,7 @@ BOOST_TOOLSETS = {
 	'edg':	  'edg',
 	'g++':	  detect_mingw,
 	'gcc':	  detect_mingw,
+	'icc': detect_intel,
 	'icpc':	 detect_intel,
 	'intel':	detect_intel,
 	'kcc':	  'kcc',

--- a/mkl.py
+++ b/mkl.py
@@ -34,7 +34,7 @@ def check_mkl(conf):
         return
     conf.env.LIB_MKL_SEQ = ["mkl_intel_lp64", "mkl_core", "mkl_sequential", "pthread", "m"]    
     conf.env.LIB_MKL_TBB = ["mkl_intel_lp64", "mkl_core", "mkl_tbb_thread", "tbb", "stdc++", "pthread", "m"]   
-    if conf.enf.CXX_NAME in ["icc", "icpc"]: 
+    if conf.env.CXX_NAME in ["icc", "icpc"]: 
         conf.env.LIB_MKL_OMP = ["mkl_intel_lp64", "mkl_core", "mkl_intel_thread", "pthread", "m"]
     else:
         conf.env.LIB_MKL_OMP = ["mkl_intel_lp64", "mkl_core", "mkl_gnu_thread", "dl", "pthread", "m"]

--- a/mkl.py
+++ b/mkl.py
@@ -1,0 +1,56 @@
+#! /usr/bin/env python
+# encoding: utf-8
+# F Allocati - 2015
+
+"""
+Quick n dirty intel mkl detection
+"""
+
+import os, glob, types
+from waflib.Configure import conf
+
+def options(opt):
+    opt.add_option('--mkl', type='string', help='path to Intel Math Kernel Library', dest='mkl')
+
+
+@conf
+def check_mkl(conf):    
+    if conf.options.mkl:
+        includes_mkl = [conf.options.mkl + '/include']        
+        libpath_mkl = [conf.options.mkl + '/lib/intel64']        
+    else:
+        includes_mkl = ['/usr/local/include', '/usr/include', '/opt/intel/mkl/include']
+        libpath_mkl = ['/usr/local/lib/', '/usr/lib', '/opt/intel/mkl/lib/intel64']
+
+    conf.start_msg('Checking Intel MKL includes')
+    try:
+        res = conf.find_file('mkl.h', includes_mkl)
+        conf.end_msg('ok')        
+        conf.start_msg('Checking Intel MKL libs')
+        res = res and conf.find_file('libmkl_core.so', libpath_mkl)
+        conf.end_msg('ok')
+    except:
+        print 'Intel MKL not found'
+        return
+    conf.env.LIB_MKL_SEQ = ["mkl_intel_lp64", "mkl_core", "mkl_sequential", "pthread", "m"]    
+    conf.env.LIB_MKL_TBB = ["mkl_intel_lp64", "mkl_core", "mkl_tbb_thread", "tbb", "stdc++", "pthread", "m"]   
+    if conf.enf.CXX_NAME in ["icc", "icpc"]: 
+        conf.env.LIB_MKL_OMP = ["mkl_intel_lp64", "mkl_core", "mkl_intel_thread", "pthread", "m"]
+    else:
+        conf.env.LIB_MKL_OMP = ["mkl_intel_lp64", "mkl_core", "mkl_gnu_thread", "dl", "pthread", "m"]
+    conf.env.INCLUDES_MKL_SEQ = includes_mkl
+    conf.env.INCLUDES_MKL_TBB = includes_mkl
+    conf.env.INCLUDES_MKL_OMP = includes_mkl
+    conf.env.LIBPATH_MKL_SEQ = libpath_mkl
+    conf.env.LIBPATH_MKL_TBB = libpath_mkl
+    conf.env.LIBPATH_MKL_OMP = libpath_mkl
+    conf.env.CXXFLAGS_MKL_SEQ = ["-m64",  "-DEIGEN_USE_MKL_ALL", "-DMKL_BLAS=MKL_DOMAIN_BLAS"] 
+    conf.env.LINKFLAGS_MKL_SEQ = [ "-Wl,--no-as-needed" ]
+    conf.env.CXXFLAGS_MKL_TBB = ["-m64",  "-DEIGEN_USE_MKL_ALL" , "-DMKL_BLAS=MKL_DOMAIN_BLAS"] 
+    conf.env.LINKFLAGS_MKL_TBB = [ "-Wl,--no-as-needed" ]
+    if  conf.env.CXX_NAME in ["icc", "icpc"]:                
+        conf.env.CXXFLAGS_MKL_OMP = ["-qopenmp", "-m64",  "-DEIGEN_USE_MKL_ALL", "-DMKL_BLAS=MKL_DOMAIN_BLAS" ] 
+    else:        
+        conf.env.CXXFLAGS_MKL_OMP = ["-fopenmp", "-m64",  "-DEIGEN_USE_MKL_ALL", "-DMKL_BLAS=MKL_DOMAIN_BLAS"] 
+    conf.end_msg('ok')
+    conf.env.LINKFLAGS_MKL_OMP = [ "-Wl,--no-as-needed" ]

--- a/openmp.py
+++ b/openmp.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+from waflib.Configure import conf
+from waflib.Errors import ConfigurationError
+
+OPENMP_CODE = '''
+#include <omp.h>
+int main () { return omp_get_num_threads (); }
+'''
+
+@conf
+def check_openmp(self, **kw):
+    self.start_msg('Checking for compiler option to support OpenMP')
+    kw.update({'fragment': OPENMP_CODE})
+    try:
+        self.validate_c(kw)
+        self.run_c_code(**kw)
+        if 'define_name' in kw:
+            self.define(kw['define_name'], 1)
+        self.end_msg('None')
+    except ConfigurationError:
+        for flag in ('-qopenmp', '-fopenmp', '-xopenmp', '-openmp', '-mp', '-omp', '-qsmp=omp'):
+            try:
+                self.validate_c(kw) #refresh env
+                if kw['compiler'] == 'c':
+                    kw['ccflags'] = kw['cflags'] = flag
+                elif kw['compiler'] == 'cxx':
+                    kw['cxxflags'] = flag
+                else:
+                    self.fatal('Compiler has to be "c" or "cxx"')
+                kw['linkflags'] = flag
+                kw['success'] = self.run_c_code(**kw)
+                self.post_check(**kw)
+                self.env.CCFLAGS_OMP =  [ flag ]
+                self.env.CXXFLAGS_OMP = [ flag ]
+                self.env.LINKFLAGS_OMP=  [ flag ]
+                self.end_msg(flag)
+                return
+            except ConfigurationError:
+                del kw['env']
+                continue
+
+        self.end_msg('Not supported')
+        if 'define_name' in kw:
+            self.undefine(kw['define_name'])
+        if kw.get('mandatory', True):
+            self.fatal('OpenMP is not supported')

--- a/wscript
+++ b/wscript
@@ -1,23 +1,26 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-VERSION='0.0.1'
-APPNAME='limbo'
+VERSION = '0.0.1'
+APPNAME = 'limbo'
 
 srcdir = '.'
 blddir = 'build'
 
 import copy
-import os, sys,glob
+import os, sys, glob
 import limbo
+
 
 def options(opt):
         opt.load('compiler_cxx boost waf_unit_test')
         opt.load('compiler_c')
         opt.load('eigen')
         opt.load('tbb')
+        opt.load('omp')
+        opt.load('mkl')
         opt.load('sferes')
-	opt.load('limbo')
+        opt.load('limbo')
         opt.add_option('--exp', type='string', help='exp(s) to build, separate by comma', dest='exp')
         opt.add_option('--qsub', type='string', help='config file (json) to submit to torque', dest='qsub')
         opt.add_option('--oar', type='string', help='config file (json) to submit to oar', dest='oar')
@@ -25,26 +28,33 @@ def options(opt):
         for i in glob.glob('exp/*'):
                 opt.recurse(i)
 
+
 def configure(conf):
-    	conf.load('compiler_cxx boost waf_unit_test')
+        conf.load('compiler_cxx boost waf_unit_test')
         conf.load('compiler_c')
         conf.load('eigen')
         conf.load('tbb')
         conf.load('sferes')
         conf.load('xcode')
 
-	if int(conf.env['CC_VERSION'][0]+conf.env['CC_VERSION'][1])<47:
-                common_flags = "-Wall -std=c++0x "
+        if conf.env.CXX_NAME in ["icc", "icpc"]:
+            common_flags = "-Wall -std=c++11"
+            opt_flags = " -O3 -xHost  -march=native -mtune=native -unroll -fma -g"
         else:
-                common_flags = "-Wall -std=c++11 "
+            if int(conf.env['CC_VERSION'][0]+conf.env['CC_VERSION'][1]) < 47:
+                common_flags = "-Wall -std=c++0x"
+            else:
+                common_flags = "-Wall -std=c++11"
+            opt_flags = " -O3 -march=native -g"
 
-	cxxflags = conf.env['CXXFLAGS']
-	conf.check_boost(lib='serialization filesystem \
+        conf.check_boost(lib='serialization filesystem \
             system unit_test_framework program_options \
             graph thread',
             min_version='1.39')
         conf.check_eigen()
         conf.check_tbb()
+        conf.check_openmp()
+        conf.check_mkl()
         conf.check_sferes()
         if conf.is_defined('USE_TBB'):
                 common_flags += " -DUSE_TBB"
@@ -52,8 +62,8 @@ def configure(conf):
         if conf.is_defined('USE_SFERES'):
                 common_flags += " -DUSE_SFERES -DSFERES_FAST_DOMSORT"
 
-        opt_flags = common_flags + ' -O3 -msse2  -g'
-        conf.env['CXXFLAGS'] = cxxflags + opt_flags.split(' ')
+        all_flags = common_flags + opt_flags
+        conf.env['CXXFLAGS'] = conf.env['CXXFLAGS'] + all_flags.split(' ')
         print conf.env['CXXFLAGS']
 
         if conf.options.exp:
@@ -63,18 +73,17 @@ def configure(conf):
 
 
 def build(bld):
-	bld.recurse('src/')
-        if bld.options.exp:
-                for i in bld.options.exp.split(','):
-                        print 'Building exp: ' + i
-                        bld.recurse('exp/' + i)
+    bld.recurse('src/')
+    if bld.options.exp:
+        for i in bld.options.exp.split(','):
+            print 'Building exp: ' + i
+            bld.recurse('exp/' + i)
         from waflib.Tools import waf_unit_test
         bld.add_post_fun(waf_unit_test.summary)
 
 
-def shutdown (ctx):
+def shutdown(ctx):
     if ctx.options.qsub:
         limbo.qsub(ctx.options.qsub)
     if ctx.options.oar:
         limbo.oar(ctx.options.oar)
-


### PR DESCRIPTION
Added mkl.py for declaration and detection of MKL.
Added openmp.py for declaration and detection of compiler OpenMP support (original code took from waf-extras repository, modified it a little).
Small modification on boost.py to support Intel Compiler (didn't worked before that).
Addition of the mkl and openmp python files to limbo wscript. Also Sublime automatically fixed styling warnings, mostly spacings and indentations (all was really bad indented when looking at it on Sublime, but maybe on OS X it looked good, so I can undo this change).