### PR TITLE
State bo

### DIFF
--- a/src/examples/mono_dim.cpp
+++ b/src/examples/mono_dim.cpp
@@ -14,9 +14,6 @@ struct Params {
     struct cmaes : public defaults::cmaes {
     };
 
-    struct meanconstant : public defaults::meanconstant {
-    };
-
     struct ucb {
         BO_PARAM(float, alpha, 0.1);
     };

--- a/src/examples/obs_multi.cpp
+++ b/src/examples/obs_multi.cpp
@@ -49,8 +49,8 @@ public:
 
     size_t dim_out() const { return _model.dim_out(); }
 
-    template <typename RewardFunction>
-    double operator()(const Eigen::VectorXd& v, const RewardFunction& rfun) const
+    template <typename AggregatorFunction>
+    double operator()(const Eigen::VectorXd& v, const AggregatorFunction& afun) const
     {
         // double mu, sigma;
         // std::tie(mu, sigma) = _model.query(v);

--- a/src/examples/obs_multi.cpp
+++ b/src/examples/obs_multi.cpp
@@ -54,7 +54,7 @@ struct Average {
     typedef double result_type;
     double operator()(const Eigen::VectorXd& x) const
     {
-        return (x(0) + x(1)) / 2;
+        return x.sum() / x.size();
     }
 };
 

--- a/src/examples/obs_multi.cpp
+++ b/src/examples/obs_multi.cpp
@@ -49,7 +49,7 @@ public:
 
     size_t dim_out() const { return _model.dim_out(); }
 
-    template<typename RewardFunction>
+    template <typename RewardFunction>
     double operator()(const Eigen::VectorXd& v, const RewardFunction& rfun) const
     {
         // double mu, sigma;

--- a/src/examples/obs_multi.cpp
+++ b/src/examples/obs_multi.cpp
@@ -14,9 +14,6 @@ struct Params {
     struct cmaes : public defaults::cmaes {
     };
 
-    struct meanconstant : public defaults::meanconstant {
-    };
-
     struct ucb {
         BO_PARAM(float, alpha, 0.1);
     };

--- a/src/examples/obs_multi.cpp
+++ b/src/examples/obs_multi.cpp
@@ -49,7 +49,8 @@ public:
 
     size_t dim_out() const { return _model.dim_out(); }
 
-    double operator()(const Eigen::VectorXd& v) const
+    template<typename RewardFunction>
+    double operator()(const Eigen::VectorXd& v, const RewardFunction& rfun) const
     {
         // double mu, sigma;
         // std::tie(mu, sigma) = _model.query(v);

--- a/src/examples/obs_multi_auto_mean.cpp
+++ b/src/examples/obs_multi_auto_mean.cpp
@@ -52,8 +52,8 @@ public:
     size_t dim_in() const { return _model.dim_in(); }
 
     size_t dim_out() const { return _model.dim_out(); }
-    
-    template<typename RewardFunction>
+
+    template <typename RewardFunction>
     double operator()(const Eigen::VectorXd& v, const RewardFunction& rfun) const
     {
         // double mu, sigma;

--- a/src/examples/obs_multi_auto_mean.cpp
+++ b/src/examples/obs_multi_auto_mean.cpp
@@ -53,8 +53,8 @@ public:
 
     size_t dim_out() const { return _model.dim_out(); }
 
-    template <typename RewardFunction>
-    double operator()(const Eigen::VectorXd& v, const RewardFunction& rfun) const
+    template <typename AggregatorFunction>
+    double operator()(const Eigen::VectorXd& v, const AggregatorFunction& afun) const
     {
         // double mu, sigma;
         // std::tie(mu, sigma) = _model.query(v);

--- a/src/examples/obs_multi_auto_mean.cpp
+++ b/src/examples/obs_multi_auto_mean.cpp
@@ -18,9 +18,6 @@ struct Params {
     struct cmaes : public defaults::cmaes {
     };
 
-    struct meanconstant : public defaults::meanconstant {
-    };
-
     struct ucb {
         BO_PARAM(float, alpha, 0.1);
     };

--- a/src/examples/obs_multi_auto_mean.cpp
+++ b/src/examples/obs_multi_auto_mean.cpp
@@ -52,8 +52,9 @@ public:
     size_t dim_in() const { return _model.dim_in(); }
 
     size_t dim_out() const { return _model.dim_out(); }
-
-    double operator()(const Eigen::VectorXd& v) const
+    
+    template<typename RewardFunction>
+    double operator()(const Eigen::VectorXd& v, const RewardFunction& rfun) const
     {
         // double mu, sigma;
         // std::tie(mu, sigma) = _model.query(v);
@@ -160,7 +161,7 @@ int main()
     BOptimizer<Params, model_fun<GP_t>, acq_fun<Acqui_t>> opt;
     opt.optimize(fit_eval());
 
-    std::cout << opt.best_observation().transpose() << " res  "
+    std::cout << opt.best_observation() << " res  "
               << opt.best_sample().transpose() << std::endl;
     return 0;
 }

--- a/src/examples/wscript
+++ b/src/examples/wscript
@@ -3,25 +3,25 @@
 
 
 def build(bld):
-	obj = bld.program(features = 'cxx',
-                          source = 'mono_dim.cpp',
-                          includes = '. .. ../../',
-                          target = 'mono_dim',
-                          uselib =  'BOOST EIGEN TBB',
-                          use = 'limbo')
-	obj = bld.program(features = 'cxx',
-                          source = 'obs_multi.cpp',
-                          includes = '. .. ../../',
-                          target = 'obs_multi',
-                          uselib =  'BOOST EIGEN TBB',
-                          use = 'limbo')
-	obj = bld.program(features = 'cxx',
-                          source = 'obs_multi_auto_mean.cpp',
-                          includes = '. .. ../../',
-                          target = 'obs_multi_auto_mean',
-                          uselib =  'BOOST EIGEN TBB',
-                          use = 'limbo')
-	# obj = bld.program(features = 'cxx',
+    obj = bld.program(features='cxx',
+                      source='mono_dim.cpp',
+                      includes='. .. ../../',
+                      target='mono_dim',
+                      uselib='BOOST EIGEN TBB',
+                      use='limbo')
+    obj = bld.program(features='cxx',
+                      source='obs_multi.cpp',
+                      includes='. .. ../../',
+                      target='obs_multi',
+                      uselib='BOOST EIGEN TBB',
+                      use='limbo')
+    obj = bld.program(features='cxx',
+                      source='obs_multi_auto_mean.cpp',
+                      includes='. .. ../../',
+                      target='obs_multi_auto_mean',
+                      uselib='BOOST EIGEN TBB',
+                      use='limbo')    
+ #   obj = bld.program(features = 'cxx',
  #                          source = 'parego.cpp',
  #                          includes = '. .. ../../',
  #                          target = 'parego',

--- a/src/limbo/acquisition_functions.hpp
+++ b/src/limbo/acquisition_functions.hpp
@@ -28,12 +28,13 @@ namespace limbo {
 
             size_t dim_out() const { return _model.dim_out(); }
 
-            double operator()(const Eigen::VectorXd& v) const
+            template<typename RewardFunction>
+            double operator()(const Eigen::VectorXd& v, const RewardFunction& rfun) const
             {
                 // double mu, sigma;
                 // std::tie(mu, sigma) = _model.query(v);
                 // return (mu + Params::ucb::alpha() * sqrt(sigma));
-                return (_model.mu(v)(0) + Params::ucb::alpha() * sqrt(_model.sigma(v)));
+                return (rfun(_model.mu(v)) + Params::ucb::alpha() * sqrt(_model.sigma(v)));
             }
 
         protected:
@@ -55,12 +56,13 @@ namespace limbo {
 
             size_t dim_out() const { return _model.dim_out(); }
 
-            double operator()(const Eigen::VectorXd& v) const
+            template<typename RewardFunction>
+            double operator()(const Eigen::VectorXd& v, const RewardFunction& rfun) const
             {
                 // double mu, sigma;
                 // std::tie(mu, sigma) = _model.query(v);
                 // return (mu + _beta * sqrt(sigma));
-                return (_model.mu(v)(0) + _beta * sqrt(_model.sigma(v)));
+                return (rfun(_model.mu(v)) + _beta * sqrt(_model.sigma(v)));
             }
 
         protected:

--- a/src/limbo/acquisition_functions.hpp
+++ b/src/limbo/acquisition_functions.hpp
@@ -34,7 +34,7 @@ namespace limbo {
                 Eigen::VectorXd mu;
                 double sigma;
                 std::tie(mu, sigma) = _model.query(v);
-                return (afun(mu) + Params::ucb::alpha() * sqrt(sigma));                
+                return (afun(mu) + Params::ucb::alpha() * sqrt(sigma));
             }
 
         protected:

--- a/src/limbo/acquisition_functions.hpp
+++ b/src/limbo/acquisition_functions.hpp
@@ -28,7 +28,7 @@ namespace limbo {
 
             size_t dim_out() const { return _model.dim_out(); }
 
-            template<typename RewardFunction>
+            template <typename RewardFunction>
             double operator()(const Eigen::VectorXd& v, const RewardFunction& rfun) const
             {
                 // double mu, sigma;
@@ -56,7 +56,7 @@ namespace limbo {
 
             size_t dim_out() const { return _model.dim_out(); }
 
-            template<typename RewardFunction>
+            template <typename RewardFunction>
             double operator()(const Eigen::VectorXd& v, const RewardFunction& rfun) const
             {
                 // double mu, sigma;

--- a/src/limbo/acquisition_functions.hpp
+++ b/src/limbo/acquisition_functions.hpp
@@ -28,13 +28,13 @@ namespace limbo {
 
             size_t dim_out() const { return _model.dim_out(); }
 
-            template <typename RewardFunction>
-            double operator()(const Eigen::VectorXd& v, const RewardFunction& rfun) const
+            template <typename AggregatorFunction>
+            double operator()(const Eigen::VectorXd& v, const AggregatorFunction& afun) const
             {
-                // double mu, sigma;
-                // std::tie(mu, sigma) = _model.query(v);
-                // return (mu + Params::ucb::alpha() * sqrt(sigma));
-                return (rfun(_model.mu(v)) + Params::ucb::alpha() * sqrt(_model.sigma(v)));
+                Eigen::VectorXd mu;
+                double sigma;
+                std::tie(mu, sigma) = _model.query(v);
+                return (afun(mu) + Params::ucb::alpha() * sqrt(sigma));                
             }
 
         protected:
@@ -56,13 +56,13 @@ namespace limbo {
 
             size_t dim_out() const { return _model.dim_out(); }
 
-            template <typename RewardFunction>
-            double operator()(const Eigen::VectorXd& v, const RewardFunction& rfun) const
+            template <typename AggregatorFunction>
+            double operator()(const Eigen::VectorXd& v, const AggregatorFunction& afun) const
             {
-                // double mu, sigma;
-                // std::tie(mu, sigma) = _model.query(v);
-                // return (mu + _beta * sqrt(sigma));
-                return (rfun(_model.mu(v)) + _beta * sqrt(_model.sigma(v)));
+                Eigen::VectorXd mu;
+                double sigma;
+                std::tie(mu, sigma) = _model.query(v);
+                return (afun(mu) + _beta * sqrt(sigma));
             }
 
         protected:

--- a/src/limbo/bo_base.hpp
+++ b/src/limbo/bo_base.hpp
@@ -47,7 +47,7 @@ namespace limbo {
         void operator()(T& x) const { x(_bo, _blacklisted); }
     };
 
-    struct NoReward {
+    struct FirstElem {
         typedef double result_type;
         double operator()(const Eigen::VectorXd& x) const
         {
@@ -170,10 +170,10 @@ namespace limbo {
                 init_function_t()(feval, *this);
         }
 
-        template <typename BO, typename RewardFunction>
-        bool _pursue(const BO& bo, const RewardFunction& rfun) const
+        template <typename BO, typename AggregatorFunction>
+        bool _pursue(const BO& bo, const AggregatorFunction& afun) const
         {
-            stopping_criterion::ChainCriteria<BO, RewardFunction> chain(bo, rfun);
+            stopping_criterion::ChainCriteria<BO, AggregatorFunction> chain(bo, afun);
             return boost::fusion::accumulate(_stopping_criteria, true, chain);
         }
 

--- a/src/limbo/bo_base.hpp
+++ b/src/limbo/bo_base.hpp
@@ -47,6 +47,14 @@ namespace limbo {
         void operator()(T& x) const { x(_bo, _blacklisted); }
     };
 
+    struct NoReward {
+        typedef double result_type;
+        double operator()(const Eigen::VectorXd& x) const
+        {
+            return x(0);
+        }
+    };
+
     // we use optimal named template parameters
     // see:
     // http://www.boost.org/doc/libs/1_55_0/libs/parameter/doc/html/index.html#parameter-enabled-class-templates
@@ -162,10 +170,10 @@ namespace limbo {
                 init_function_t()(feval, *this);
         }
 
-        template <typename BO>
-        bool _pursue(const BO& bo) const
+        template <typename BO, typename RewardFunction>
+        bool _pursue(const BO& bo, const RewardFunction& rfun) const
         {
-            stopping_criterion::ChainCriteria<BO> chain(bo);
+            stopping_criterion::ChainCriteria<BO, RewardFunction> chain(bo, rfun);
             return boost::fusion::accumulate(_stopping_criteria, true, chain);
         }
 

--- a/src/limbo/boptimizer.hpp
+++ b/src/limbo/boptimizer.hpp
@@ -5,14 +5,6 @@
 #include <boost/range/adaptor/transformed.hpp>
 
 namespace limbo {
-    struct NoReward {
-        typedef double result_type;
-        double operator()(const Eigen::VectorXd& x) const
-        {            
-            return x(0);
-        }
-    };
-
     template <class Params, class A1 = boost::parameter::void_,
         class A2 = boost::parameter::void_, class A3 = boost::parameter::void_,
         class A4 = boost::parameter::void_, class A5 = boost::parameter::void_,
@@ -36,7 +28,7 @@ namespace limbo {
                     Params::boptimizer::noise());
             inner_optimization_t inner_optimization;
 
-            while (this->_samples.size() == 0 || this->_pursue(*this)) {
+            while (this->_samples.size() == 0 || this->_pursue(*this, rfun)) {
                 acquisition_function_t acqui(_model, this->_iteration);
 
                 Eigen::VectorXd new_sample = inner_optimization(acqui, acqui.dim_in(), rfun);

--- a/src/limbo/boptimizer.hpp
+++ b/src/limbo/boptimizer.hpp
@@ -60,7 +60,7 @@ namespace limbo {
                 //<< " sigma: "<< _model.sigma(blacklisted ? this->_bl_samples.back() :
                 //this->_samples.back())
                 //<< " acqui: "<< acqui(blacklisted ? this->_bl_samples.back() :
-                //this->_samples.back())
+                //this->_samples.back(), afun)
                 std::cout << " best:" << this->best_observation(afun) << std::endl;
 
                 this->_iteration++;

--- a/src/limbo/ehvi.hpp
+++ b/src/limbo/ehvi.hpp
@@ -56,7 +56,7 @@ namespace limbo {
 
             inner_optimization_t inner_opt;
 
-            while (this->_samples.size() == 0 || this->_pursue(*this, NoReward())) {
+            while (this->_samples.size() == 0 || this->_pursue(*this, FirstElem())) {
                 std::cout.flush();
                 this->template update_pareto_model<EvalFunction::dim>();
                 this->update_pareto_data();
@@ -85,7 +85,7 @@ namespace limbo {
                 auto body = [&](int i) -> pair_t {
                     // clang-format off
                     auto x = this->pareto_data()[i];
-                    Eigen::VectorXd s = inner_opt(acqui, acqui.dim(), std::get<0>(x), NoReward());
+                    Eigen::VectorXd s = inner_opt(acqui, acqui.dim(), std::get<0>(x), FirstElem());
                     double hv = acqui(s);
                     return std::make_pair(s, hv);
                     // clang-format on

--- a/src/limbo/ehvi.hpp
+++ b/src/limbo/ehvi.hpp
@@ -56,7 +56,7 @@ namespace limbo {
 
             inner_optimization_t inner_opt;
 
-            while (this->_samples.size() == 0 || this->_pursue(*this)) {
+            while (this->_samples.size() == 0 || this->_pursue(*this, NoReward())) {
                 std::cout.flush();
                 this->template update_pareto_model<EvalFunction::dim>();
                 this->update_pareto_data();
@@ -85,7 +85,7 @@ namespace limbo {
                 auto body = [&](int i) -> pair_t {
                     // clang-format off
                     auto x = this->pareto_data()[i];
-                    Eigen::VectorXd s = inner_opt(acqui, acqui.dim(), std::get<0>(x));
+                    Eigen::VectorXd s = inner_opt(acqui, acqui.dim(), std::get<0>(x), NoReward());
                     double hv = acqui(s);
                     return std::make_pair(s, hv);
                     // clang-format on

--- a/src/limbo/inner_cmaes.hpp
+++ b/src/limbo/inner_cmaes.hpp
@@ -28,15 +28,15 @@ namespace limbo {
         struct Cmaes {
             Cmaes() {}
 
-            template <typename AcquisitionFunction>
-            Eigen::VectorXd operator()(const AcquisitionFunction& acqui, int dim_in) const
+            template <typename AcquisitionFunction, typename RewardFunction >
+            Eigen::VectorXd operator()(const AcquisitionFunction& acqui, int dim_in, const RewardFunction& rfun) const
             {
                 return this->operator()(acqui, dim_in,
-                    Eigen::VectorXd::Constant(dim_in, 0.5));
+                    Eigen::VectorXd::Constant(dim_in, 0.5), rfun);
             }
 
-            template <typename AcquisitionFunction>
-            Eigen::VectorXd operator()(const AcquisitionFunction& acqui, int dim_in, const Eigen::VectorXd& init) const
+            template <typename AcquisitionFunction, typename RewardFunction>
+            Eigen::VectorXd operator()(const AcquisitionFunction& acqui, int dim_in, const Eigen::VectorXd& init, const RewardFunction& rfun) const
             {
 
                 int nrestarts = Params::cmaes::nrestarts();
@@ -82,7 +82,7 @@ namespace limbo {
                                 boundary_transformation(&boundaries, pop[i], all_x_in_bounds[i], dim_in);
                                 for (int j = 0; j < dim_in; ++j)
                                   pop_eigen[i](j) = all_x_in_bounds[i][j];
-                                fitvals[i] = -acqui(pop_eigen[i]);
+                                fitvals[i] = -acqui(pop_eigen[i], rfun);
                             // clang-format on
                         });
                         cmaes_UpdateDistribution(&evo, fitvals);
@@ -104,7 +104,7 @@ namespace limbo {
                     for (int j = 0; j < v.size(); ++j)
                         v(j) = xmean[j];
 
-                    if ((fmean = -acqui(v)) < fbestever) {
+                    if ((fmean = -acqui(v, rfun)) < fbestever) {
                         fbestever = fmean;
                         xbestever = cmaes_GetInto(&evo, "xmean", xbestever);
                     }

--- a/src/limbo/inner_cmaes.hpp
+++ b/src/limbo/inner_cmaes.hpp
@@ -28,15 +28,15 @@ namespace limbo {
         struct Cmaes {
             Cmaes() {}
 
-            template <typename AcquisitionFunction, typename RewardFunction>
-            Eigen::VectorXd operator()(const AcquisitionFunction& acqui, int dim_in, const RewardFunction& rfun) const
+            template <typename AcquisitionFunction, typename AggregatorFunction>
+            Eigen::VectorXd operator()(const AcquisitionFunction& acqui, int dim_in, const AggregatorFunction& afun) const
             {
                 return this->operator()(acqui, dim_in,
-                    Eigen::VectorXd::Constant(dim_in, 0.5), rfun);
+                    Eigen::VectorXd::Constant(dim_in, 0.5), afun);
             }
 
-            template <typename AcquisitionFunction, typename RewardFunction>
-            Eigen::VectorXd operator()(const AcquisitionFunction& acqui, int dim_in, const Eigen::VectorXd& init, const RewardFunction& rfun) const
+            template <typename AcquisitionFunction, typename AggregatorFunction>
+            Eigen::VectorXd operator()(const AcquisitionFunction& acqui, int dim_in, const Eigen::VectorXd& init, const AggregatorFunction& afun) const
             {
 
                 int nrestarts = Params::cmaes::nrestarts();
@@ -82,7 +82,7 @@ namespace limbo {
                                 boundary_transformation(&boundaries, pop[i], all_x_in_bounds[i], dim_in);
                                 for (int j = 0; j < dim_in; ++j)
                                   pop_eigen[i](j) = all_x_in_bounds[i][j];
-                                fitvals[i] = -acqui(pop_eigen[i], rfun);
+                                fitvals[i] = -acqui(pop_eigen[i], afun);
                             // clang-format on
                         });
                         cmaes_UpdateDistribution(&evo, fitvals);
@@ -104,7 +104,7 @@ namespace limbo {
                     for (int j = 0; j < v.size(); ++j)
                         v(j) = xmean[j];
 
-                    if ((fmean = -acqui(v, rfun)) < fbestever) {
+                    if ((fmean = -acqui(v, afun)) < fbestever) {
                         fbestever = fmean;
                         xbestever = cmaes_GetInto(&evo, "xmean", xbestever);
                     }

--- a/src/limbo/inner_cmaes.hpp
+++ b/src/limbo/inner_cmaes.hpp
@@ -28,7 +28,7 @@ namespace limbo {
         struct Cmaes {
             Cmaes() {}
 
-            template <typename AcquisitionFunction, typename RewardFunction >
+            template <typename AcquisitionFunction, typename RewardFunction>
             Eigen::VectorXd operator()(const AcquisitionFunction& acqui, int dim_in, const RewardFunction& rfun) const
             {
                 return this->operator()(acqui, dim_in,

--- a/src/limbo/inner_optimization.hpp
+++ b/src/limbo/inner_optimization.hpp
@@ -12,8 +12,8 @@ namespace limbo {
         struct Random {
             Random() {}
 
-            template <typename AcquisitionFunction, typename RewardFunction>
-            Eigen::VectorXd operator()(const AcquisitionFunction& acqui, int dim_in, const RewardFunction& rfun) const
+            template <typename AcquisitionFunction, typename AggregatorFunction>
+            Eigen::VectorXd operator()(const AcquisitionFunction& acqui, int dim_in, const AggregatorFunction& afun) const
             {
                 return Eigen::VectorXd::Random(dim_in);
             }
@@ -23,16 +23,16 @@ namespace limbo {
         struct ExhaustiveSearch {
             ExhaustiveSearch() { nb_pts = Params::exhaustivesearch::nb_pts; }
 
-            template <typename AcquisitionFunction, typename RewardFunction>
-            Eigen::VectorXd operator()(const AcquisitionFunction& acqui, int dim_in, const RewardFunction& rfun) const
+            template <typename AcquisitionFunction, typename AggregatorFunction>
+            Eigen::VectorXd operator()(const AcquisitionFunction& acqui, int dim_in, const AggregatorFunction& afun) const
             {
-                return explore(0, acqui, rfun, Eigen::VectorXd::Constant(dim_in, 0));
+                return explore(0, acqui, afun, Eigen::VectorXd::Constant(dim_in, 0));
             }
 
         private:
             // recursive exploration
-            template <typename AcquisitionFunction, typename RewardFunction>
-            Eigen::VectorXd explore(int dim_in, const AcquisitionFunction& acqui, const RewardFunction& rfun,
+            template <typename AcquisitionFunction, typename AggregatorFunction>
+            Eigen::VectorXd explore(int dim_in, const AcquisitionFunction& acqui, const AggregatorFunction& afun,
                 const Eigen::VectorXd& current,
                 Eigen::VectorXd& result) const
             {
@@ -44,7 +44,7 @@ namespace limbo {
                     point[dim_in] = x;
                     double val;
                     if (dim_in == current.size() - 1) {
-                        val = acqui(point, rfun);
+                        val = acqui(point, afun);
                         if (val > best_fit) {
                             best_fit = val;
                             current_result = point;
@@ -52,7 +52,7 @@ namespace limbo {
                     }
                     else {
                         Eigen::VectorXd temp_result = current_result;
-                        std::tie(temp_result, val) = explore(dim_in + 1, acqui, rfun, point, temp_result);
+                        std::tie(temp_result, val) = explore(dim_in + 1, acqui, afun, point, temp_result);
                         if (val > best_fit) {
                             best_fit = val;
                             current_result = temp_result;

--- a/src/limbo/inner_optimization.hpp
+++ b/src/limbo/inner_optimization.hpp
@@ -12,8 +12,8 @@ namespace limbo {
         struct Random {
             Random() {}
 
-            template <typename AcquisitionFunction>
-            Eigen::VectorXd operator()(const AcquisitionFunction& acqui, int dim_in) const
+            template <typename AcquisitionFunction, typename RewardFunction>
+            Eigen::VectorXd operator()(const AcquisitionFunction& acqui, int dim_in, const RewardFunction& rfun) const
             {
                 return Eigen::VectorXd::Random(dim_in);
             }
@@ -23,16 +23,16 @@ namespace limbo {
         struct ExhaustiveSearch {
             ExhaustiveSearch() { nb_pts = Params::exhaustivesearch::nb_pts; }
 
-            template <typename AcquisitionFunction>
-            Eigen::VectorXd operator()(const AcquisitionFunction& acqui, int dim_in) const
+            template <typename AcquisitionFunction, typename RewardFunction>
+            Eigen::VectorXd operator()(const AcquisitionFunction& acqui, int dim_in, const RewardFunction& rfun) const
             {
-                return explore(0, acqui, Eigen::VectorXd::Constant(dim_in, 0));
+                return explore(0, acqui, rfun, Eigen::VectorXd::Constant(dim_in, 0));
             }
 
         private:
             // recursive exploration
-            template <typename AcquisitionFunction>
-            Eigen::VectorXd explore(int dim_in, const AcquisitionFunction& acqui,
+            template <typename AcquisitionFunction, typename RewardFunction>
+            Eigen::VectorXd explore(int dim_in, const AcquisitionFunction& acqui, const RewardFunction& rfun,
                 const Eigen::VectorXd& current,
                 Eigen::VectorXd& result) const
             {
@@ -44,7 +44,7 @@ namespace limbo {
                     point[dim_in] = x;
                     double val;
                     if (dim_in == current.size() - 1) {
-                        val = acqui(point);
+                        val = acqui(point, rfun);
                         if (val > best_fit) {
                             best_fit = val;
                             current_result = point;
@@ -52,7 +52,7 @@ namespace limbo {
                     }
                     else {
                         Eigen::VectorXd temp_result = current_result;
-                        std::tie(temp_result, val) = explore(dim_in + 1, acqui, point, temp_result);
+                        std::tie(temp_result, val) = explore(dim_in + 1, acqui, rfun, point, temp_result);
                         if (val > best_fit) {
                             best_fit = val;
                             current_result = temp_result;

--- a/src/limbo/inner_optimization.hpp
+++ b/src/limbo/inner_optimization.hpp
@@ -13,7 +13,7 @@ namespace limbo {
             Random() {}
 
             template <typename AcquisitionFunction, typename AggregatorFunction>
-            Eigen::VectorXd operator()(const AcquisitionFunction& acqui, int dim_in, const AggregatorFunction& afun) const
+            Eigen::VectorXd operator()(const AcquisitionFunction& acqui, int dim_in, const AggregatorFunction&) const
             {
                 return Eigen::VectorXd::Random(dim_in);
             }

--- a/src/limbo/kernel_functions.hpp
+++ b/src/limbo/kernel_functions.hpp
@@ -10,7 +10,7 @@ namespace limbo {
             Exp(size_t dim = 1) {}
             double operator()(const Eigen::VectorXd& v1, const Eigen::VectorXd& v2) const
             {
-                double _sigma = Params::kf_exp::sigma;
+                double _sigma = Params::kf_exp::sigma();
                 return (exp(-(1 / (2 * pow(_sigma, 2))) * pow((v1 - v2).norm(), 2)));
             }
         };

--- a/src/limbo/limbo.hpp
+++ b/src/limbo/limbo.hpp
@@ -12,6 +12,8 @@
 #include "mean_functions.hpp"
 #include "inner_optimization.hpp"
 #include "gp.hpp"
+#include "gp_auto.hpp"
+#include "gp_auto_mean.hpp"
 #include "init_functions.hpp"
 
 #endif

--- a/src/limbo/macros.hpp
+++ b/src/limbo/macros.hpp
@@ -60,5 +60,5 @@
     }
 
 #define BO_STRING(Name, Value) static constexpr const char* Name() { return Value; }
-// clang-format on
+         // clang-format on
 #endif

--- a/src/limbo/macros.hpp
+++ b/src/limbo/macros.hpp
@@ -2,63 +2,64 @@
 #define _BO_MACROS_HPP_
 
 #include <Eigen/Core>
-// clang-format off
+
 #define BO_PARAM(Type, Name, Value) \
     static constexpr Type Name() { return Value; }
 
-#define BO_REQUIRED_PARAM(Type, Name) \
-    static const Type Name() \
-    { \
+#define BO_REQUIRED_PARAM(Type, Name)                                         \
+    static const Type Name()                                                  \
+    {                                                                         \
         static_assert(false, "You need to define the parameter:" #Name " !"); \
-        return Type(); \
+        return Type();                                                        \
     }
 
-#define BO_DYN_PARAM(Type, Name) \
-    static Type _##Name; \
+#define BO_DYN_PARAM(Type, Name)           \
+    static Type _##Name;                   \
     static Type Name() { return _##Name; } \
     static void set_##Name(const Type& v) { _##Name = v; }
 
 #define BO_DECLARE_DYN_PARAM(Type, Namespace, Name) Type Namespace::_##Name;
 
-#define __VA_NARG__(...) (__VA_NARG_(_0, ## __VA_ARGS__, __RSEQ_N()) - 1) 
-#define __VA_NARG_(...) __VA_ARG_N(__VA_ARGS__) 
-#define __VA_ARG_N( \ 
-         _1, _2, _3, _4, _5, _6, _7, _8, _9,_10, \ 
-        _11,_12,_13,_14,_15,_16,_17,_18,_19,_20, \ 
-        _21,_22,_23,_24,_25,_26,_27,_28,_29,_30, \ 
-        _31,_32,_33,_34,_35,_36,_37,_38,_39,_40, \ 
-        _41,_42,_43,_44,_45,_46,_47,_48,_49,_50, \ 
-        _51,_52,_53,_54,_55,_56,_57,_58,_59,_60, \ 
-        _61,_62,_63,N,...) N 
-#define __RSEQ_N() \ 
-        63, 62, 61, 60, \ 
-        59, 58, 57, 56, 55, 54, 53, 52, 51, 50, \ 
-        49, 48, 47, 46, 45, 44, 43, 42, 41, 40, \ 
-        39, 38, 37, 36, 35, 34, 33, 32, 31, 30, \ 
-        29, 28, 27, 26, 25, 24, 23, 22, 21, 20, \ 
-        19, 18, 17, 16, 15, 14, 13, 12, 11, 10, \ 
-         9,  8,  7,  6,  5,  4,  3,  2,  1,  0 
+#define __VA_NARG__(...) (__VA_NARG_(_0, ##__VA_ARGS__, __RSEQ_N()) - 1)
+#define __VA_NARG_(...) __VA_ARG_N(__VA_ARGS__)
+#define __VA_ARG_N(                                   \
+    _1, _2, _3, _4, _5, _6, _7, _8, _9, _10,          \
+    _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, \
+    _21, _22, _23, _24, _25, _26, _27, _28, _29, _30, \
+    _31, _32, _33, _34, _35, _36, _37, _38, _39, _40, \
+    _41, _42, _43, _44, _45, _46, _47, _48, _49, _50, \
+    _51, _52, _53, _54, _55, _56, _57, _58, _59, _60, \
+    _61, _62, _63, N, ...) N
+#define __RSEQ_N()                              \
+    63, 62, 61, 60,                             \
+        59, 58, 57, 56, 55, 54, 53, 52, 51, 50, \
+        49, 48, 47, 46, 45, 44, 43, 42, 41, 40, \
+        39, 38, 37, 36, 35, 34, 33, 32, 31, 30, \
+        29, 28, 27, 26, 25, 24, 23, 22, 21, 20, \
+        19, 18, 17, 16, 15, 14, 13, 12, 11, 10, \
+        9, 8, 7, 6, 5, 4, 3, 2, 1, 0
 
-#define BO_PARAM_ARRAY(Type, Name, ...) \
-    static Type Name(size_t i) \
-    { \
-        assert(i < __VA_NARG__(__VA_ARGS__)); \
+#define BO_PARAM_ARRAY(Type, Name, ...)                  \
+    static Type Name(size_t i)                           \
+    {                                                    \
+        assert(i < __VA_NARG__(__VA_ARGS__));            \
         static constexpr Type _##Name[] = {__VA_ARGS__}; \
-        return _##Name[i]; \
-    } \
-    static constexpr size_t Name##_size() \
-    { \
-        return __VA_NARG__(__VA_ARGS__); \
-    } \
+        return _##Name[i];                               \
+    }                                                    \
+    static constexpr size_t Name##_size()                \
+    {                                                    \
+        return __VA_NARG__(__VA_ARGS__);                 \
+    }                                                    \
     typedef Type Name##_t;
 
-#define BO_PARAM_VECTOR(Type, Name, ...) \
-    static const Eigen::Matrix<Type, __VA_NARG__(__VA_ARGS__), 1>  Name() \
-    {                                                    \
-        static constexpr Type _##Name[] = {__VA_ARGS__}; \
+#define BO_PARAM_VECTOR(Type, Name, ...)                                                    \
+    static const Eigen::Matrix<Type, __VA_NARG__(__VA_ARGS__), 1> Name()                    \
+    {                                                                                       \
+        static constexpr Type _##Name[] = {__VA_ARGS__};                                    \
         return Eigen::Map<const Eigen::Matrix<Type, __VA_NARG__(__VA_ARGS__), 1>>(_##Name); \
     }
 
-#define BO_PARAM_STRING(Name, Value) static constexpr const char* Name() { return Value; }
-         // clang-format on
+#define BO_PARAM_STRING(Name, Value) \
+    static constexpr const char* Name() { return Value; }
+
 #endif

--- a/src/limbo/macros.hpp
+++ b/src/limbo/macros.hpp
@@ -7,9 +7,9 @@
     static constexpr Type Name() { return Value; }
 
 #define BO_REQUIRED_PARAM(Type, Name) \
-    static constexpr Type Name() \
+    static const Type Name() \
     { \
-        static_assert(false, "You need to define the parameter:"##Name##" !"); \
+        static_assert(false, "You need to define the parameter:" #Name " !"); \
         return Type(); \
     }
 
@@ -59,6 +59,6 @@
         return Eigen::Map<const Eigen::Matrix<Type, __VA_NARG__(__VA_ARGS__), 1>>(_##Name); \
     }
 
-#define BO_STRING(Name, Value) static constexpr const char* Name() { return Value; }
+#define BO_PARAM_STRING(Name, Value) static constexpr const char* Name() { return Value; }
          // clang-format on
 #endif

--- a/src/limbo/mean_functions.hpp
+++ b/src/limbo/mean_functions.hpp
@@ -6,7 +6,7 @@
 #include <boost/serialization/vector.hpp>
 #include <boost/archive/text_oarchive.hpp>
 #include <boost/archive/text_iarchive.hpp>
-namespace limbo {    
+namespace limbo {
     namespace mean_functions {
         template <typename Params, typename ObsType = Eigen::VectorXd>
         struct NullFunction {

--- a/src/limbo/mean_functions.hpp
+++ b/src/limbo/mean_functions.hpp
@@ -6,12 +6,7 @@
 #include <boost/serialization/vector.hpp>
 #include <boost/archive/text_oarchive.hpp>
 #include <boost/archive/text_iarchive.hpp>
-namespace limbo {
-    namespace defaults {
-        struct meanconstant {
-            BO_PARAM(double, constant, 0.0);
-        };
-    }
+namespace limbo {    
     namespace mean_functions {
         template <typename Params, typename ObsType = Eigen::VectorXd>
         struct NullFunction {
@@ -20,7 +15,7 @@ namespace limbo {
             template <typename GP>
             ObsType operator()(const Eigen::VectorXd& v, const GP&) const
             {
-                return ObsType::Zeros(_dim_out);
+                return ObsType::Zero(_dim_out);
             }
 
         protected:

--- a/src/limbo/nsbo.hpp
+++ b/src/limbo/nsbo.hpp
@@ -20,7 +20,7 @@ namespace limbo {
         {
             this->_init(feval, reset);
 
-            while (this->_samples.size() == 0 || this->_pursue(*this)) {
+            while (this->_samples.size() == 0 || this->_pursue(*this, NoReward())) {
                 std::cout << "updating pareto model...";
                 std::cout.flush();
                 this->template update_pareto_model<EvalFunction::dim>();

--- a/src/limbo/nsbo.hpp
+++ b/src/limbo/nsbo.hpp
@@ -20,7 +20,7 @@ namespace limbo {
         {
             this->_init(feval, reset);
 
-            while (this->_samples.size() == 0 || this->_pursue(*this, NoReward())) {
+            while (this->_samples.size() == 0 || this->_pursue(*this, FirstElem())) {
                 std::cout << "updating pareto model...";
                 std::cout.flush();
                 this->template update_pareto_model<EvalFunction::dim>();

--- a/src/limbo/parego.hpp
+++ b/src/limbo/parego.hpp
@@ -36,10 +36,10 @@ namespace limbo {
 
             inner_optimization_t inner_optimization;
 
-            while (this->_samples.size() == 0 || this->_pursue(*this, NoReward())) {
+            while (this->_samples.size() == 0 || this->_pursue(*this, FirstElem())) {
                 acquisition_function_t acqui(model, this->_iteration);
 
-                Eigen::VectorXd new_sample = inner_optimization(acqui, acqui.dim(), NoReward());
+                Eigen::VectorXd new_sample = inner_optimization(acqui, acqui.dim(), FirstElem());
                 this->add_new_sample(new_sample, feval(new_sample));
                 std::cout << this->_iteration
                           << " | new sample:" << new_sample.transpose() << " => "

--- a/src/limbo/parego.hpp
+++ b/src/limbo/parego.hpp
@@ -36,10 +36,10 @@ namespace limbo {
 
             inner_optimization_t inner_optimization;
 
-            while (this->_samples.size() == 0 || this->_pursue(*this)) {
+            while (this->_samples.size() == 0 || this->_pursue(*this, NoReward())) {
                 acquisition_function_t acqui(model, this->_iteration);
 
-                Eigen::VectorXd new_sample = inner_optimization(acqui, acqui.dim());
+                Eigen::VectorXd new_sample = inner_optimization(acqui, acqui.dim(), NoReward());
                 this->add_new_sample(new_sample, feval(new_sample));
                 std::cout << this->_iteration
                           << " | new sample:" << new_sample.transpose() << " => "

--- a/src/limbo/stopping_criterion.hpp
+++ b/src/limbo/stopping_criterion.hpp
@@ -70,7 +70,7 @@ namespace limbo {
                 double operator()(const Eigen::VectorXd& v, const AggregatorFunction afun) const { return afun(_model.mu(v)); }
 
                 int dim_in() const
-                {                    
+                {
                     return _model.dim_in();
                 }
 

--- a/src/limbo/stopping_criterion.hpp
+++ b/src/limbo/stopping_criterion.hpp
@@ -20,8 +20,8 @@ namespace limbo {
         struct MaxIterations {
             MaxIterations() { iteration = 0; }
 
-            template <typename BO, typename RewardFunction>
-            bool operator()(const BO& bo, const RewardFunction&)
+            template <typename BO, typename AggregatorFunction>
+            bool operator()(const BO& bo, const AggregatorFunction&)
             {
                 return bo.iteration() <= Params::maxiterations::n_iterations();
             }
@@ -35,19 +35,19 @@ namespace limbo {
 
             MaxPredictedValue() {}
 
-            template <typename BO, typename RewardFunction>
-            bool operator()(const BO& bo, const RewardFunction& rfun)
+            template <typename BO, typename AggregatorFunction>
+            bool operator()(const BO& bo, const AggregatorFunction& afun)
             {
                 GPMean<BO> gpmean(bo);
                 typename BO::inner_optimization_t opti;
-                double val = rfun(gpmean(opti(gpmean, 0, rfun)));
+                double val = afun(gpmean(opti(gpmean, 0, afun)));
 
-                if (bo.observations().size() == 0 || bo.best_observation(rfun) <= Params::maxpredictedvalue::ratio() * val)
+                if (bo.observations().size() == 0 || bo.best_observation(afun) <= Params::maxpredictedvalue::ratio() * val)
                     return true;
                 else {
                     std::cout << "stop caused by Max predicted value reached. Thresold: "
                               << Params::maxpredictedvalue::ratio() * val
-                              << " max observations: " << bo.best_observation(rfun) << std::endl;
+                              << " max observations: " << bo.best_observation(afun) << std::endl;
                     return false;
                 }
             }
@@ -69,20 +69,20 @@ namespace limbo {
             };
         };
 
-        template <typename BO, typename RewardFunction>
+        template <typename BO, typename AggregatorFunction>
         struct ChainCriteria {
             typedef bool result_type;
-            ChainCriteria(const BO& bo, const RewardFunction& rfun) : _bo(bo), _rfun(rfun) {}
+            ChainCriteria(const BO& bo, const AggregatorFunction& afun) : _bo(bo), _afun(afun) {}
 
             template <typename stopping_criterion>
             bool operator()(bool state, stopping_criterion stop) const
             {
-                return state && stop(_bo, _rfun);
+                return state && stop(_bo, _afun);
             }
 
         protected:
             const BO& _bo;
-            const RewardFunction& _rfun;
+            const AggregatorFunction& _afun;
         };
     }
 }

--- a/src/limbo/stopping_criterion.hpp
+++ b/src/limbo/stopping_criterion.hpp
@@ -38,13 +38,13 @@ namespace limbo {
             template <typename BO, typename AggregatorFunction>
             bool operator()(const BO& bo, const AggregatorFunction& afun)
             {
-                // Prevent instantiation of GPMean if there are no observed samples
+                // Prevent instantiation of GPMean if there are no observed samplesgit
                 if (bo.observations().size() == 0)
                     return true;
 
                 GPMean<BO> gpmean(bo);
                 typename BO::inner_optimization_t opti;
-                double val = afun(gpmean(opti(gpmean, 0, afun)));
+                double val = gpmean(opti(gpmean, 0, afun), afun);
 
                 if (bo.observations().size() == 0 || bo.best_observation(afun) <= Params::maxpredictedvalue::ratio() * val)
                     return true;
@@ -66,7 +66,13 @@ namespace limbo {
                         BO::params_t::boptimizer::noise());
                 }
 
-                Eigen::VectorXd operator()(const Eigen::VectorXd& v) const { return _model.mu(v); }
+                template <typename AggregatorFunction>
+                double operator()(const Eigen::VectorXd& v, const AggregatorFunction afun) const { return afun(_model.mu(v)); }
+
+                int dim_in() const
+                {                    
+                    return _model.dim_in();
+                }
 
             protected:
                 typename BO::model_t _model;

--- a/src/limbo/stopping_criterion.hpp
+++ b/src/limbo/stopping_criterion.hpp
@@ -38,6 +38,10 @@ namespace limbo {
             template <typename BO, typename AggregatorFunction>
             bool operator()(const BO& bo, const AggregatorFunction& afun)
             {
+                // Prevent instantiation of GPMean if there are no observed samples
+                if (bo.observations().size() == 0)
+                    return true;
+
                 GPMean<BO> gpmean(bo);
                 typename BO::inner_optimization_t opti;
                 double val = afun(gpmean(opti(gpmean, 0, afun)));
@@ -56,7 +60,7 @@ namespace limbo {
             template <typename BO>
             struct GPMean {
                 GPMean(const BO& bo)
-                    : _model(bo.samples()[0].size())
+                    : _model(bo.samples()[0].size(), bo.observations()[0].size())
                 { // should have at least one sample
                     _model.compute(bo.samples(), bo.observations(),
                         BO::params_t::boptimizer::noise());

--- a/src/limbo/stopping_criterion.hpp
+++ b/src/limbo/stopping_criterion.hpp
@@ -20,8 +20,8 @@ namespace limbo {
         struct MaxIterations {
             MaxIterations() { iteration = 0; }
 
-            template <typename BO>
-            bool operator()(const BO& bo)
+            template <typename BO, typename RewardFunction>
+            bool operator()(const BO& bo, const RewardFunction&)
             {
                 return bo.iteration() <= Params::maxiterations::n_iterations();
             }
@@ -35,19 +35,19 @@ namespace limbo {
 
             MaxPredictedValue() {}
 
-            template <typename BO>
-            bool operator()(const BO& bo)
+            template <typename BO, typename RewardFunction>
+            bool operator()(const BO& bo, const RewardFunction& rfun)
             {
                 GPMean<BO> gpmean(bo);
                 typename BO::inner_optimization_t opti;
-                double val = gpmean(opti(gpmean, 0));
+                double val = rfun(gpmean(opti(gpmean, 0, rfun)));
 
-                if (bo.observations().size() == 0 || bo.best_observation() <= Params::maxpredictedvalue::ratio() * val)
+                if (bo.observations().size() == 0 || bo.best_observation(rfun) <= Params::maxpredictedvalue::ratio() * val)
                     return true;
                 else {
                     std::cout << "stop caused by Max predicted value reached. Thresold: "
                               << Params::maxpredictedvalue::ratio() * val
-                              << " max observations: " << bo.best_observation() << std::endl;
+                              << " max observations: " << bo.best_observation(rfun) << std::endl;
                     return false;
                 }
             }
@@ -62,26 +62,27 @@ namespace limbo {
                         BO::params_t::boptimizer::noise());
                 }
 
-                double operator()(const Eigen::VectorXd& v) const { return _model.mu(v); }
+                Eigen::VectorXd operator()(const Eigen::VectorXd& v) const { return _model.mu(v); }
 
             protected:
                 typename BO::model_t _model;
             };
         };
 
-        template <typename BO>
+        template <typename BO, typename RewardFunction>
         struct ChainCriteria {
             typedef bool result_type;
-            ChainCriteria(const BO& bo) : _bo(bo) {}
+            ChainCriteria(const BO& bo, const RewardFunction& rfun) : _bo(bo), _rfun(rfun) {}
 
             template <typename stopping_criterion>
             bool operator()(bool state, stopping_criterion stop) const
             {
-                return state && stop(_bo);
+                return state && stop(_bo, _rfun);
             }
 
         protected:
             const BO& _bo;
+            const RewardFunction& _rfun;
         };
     }
 }

--- a/src/tests/all_combinations.cpp
+++ b/src/tests/all_combinations.cpp
@@ -1,0 +1,235 @@
+//#define SHOW_TIMER
+#include <boost/fusion/container/vector.hpp>
+#include <boost/fusion/include/vector.hpp>
+
+#include "limbo/limbo.hpp"
+
+using namespace limbo;
+
+struct Params {
+
+   struct kf_exp {
+        BO_PARAM(double, sigma, 1);
+    };
+
+    struct kf_maternthreehalfs {
+        BO_PARAM(double, sigma, 1);
+        BO_PARAM(double, l, 0.2);
+    };
+
+    struct kf_maternfivehalfs {
+        BO_PARAM(double, sigma, 1);
+        BO_PARAM(double, l, 0.2);
+    };
+
+     struct meanconstant {
+        BO_PARAM_VECTOR(double, constant, 0, 0);
+    };
+
+    struct meanarchive{
+        BO_PARAM_STRING(filename, "missing");
+    };
+
+    struct gp_auto : defaults::gp_auto {
+    };
+
+    struct gp_auto_mean : defaults::gp_auto_mean {
+    };
+
+    struct ucb : public defaults::ucb {
+    };
+
+    struct gp_ucb : public defaults::gp_ucb {
+    };
+
+    struct exhaustivesearch {
+        BO_PARAM(int, nb_pts, 20);
+    };
+
+    struct cmaes : public defaults::cmaes {
+    };
+
+    struct init {
+        BO_PARAM(int, nb_samples, 5);
+        BO_PARAM(int, nb_bins, 5);
+    };
+
+    struct maxiterations {
+        BO_PARAM(int, n_iterations, 20);
+    };
+
+    struct maxpredictedvalue : public defaults::maxpredictedvalue {
+    };
+
+    struct boptimizer {
+        BO_PARAM(double, noise, 0.001);
+        BO_PARAM(int, dump_period, 1);
+    };
+};
+
+struct MeanEval
+{
+    MeanEval(size_t dim_out = 1) {}
+
+    template <typename GP>
+    Eigen::VectorXd operator()(const Eigen::VectorXd& x, const GP&) const
+    {
+        Eigen::VectorXd res(2);
+        res(0) = 2.5 * x(0);
+        res(1) = -4.5 * x(1);
+        return res;
+    }
+};
+
+struct Average {
+    typedef double result_type;
+    double operator()(const Eigen::VectorXd& x) const
+    {
+        return (x(0) + x(1)) / 2;
+    }
+};
+
+struct StateEval {
+    static constexpr size_t dim_in = 2;
+    static constexpr size_t dim_out = 2;
+
+    Eigen::VectorXd operator()(const Eigen::VectorXd& x) const
+    {
+        Eigen::VectorXd res(2);
+        res(0) = 3 * x(0) + 5;
+        res(1) = -5 * x(1) + 2;
+        return res;
+    }
+};
+
+int main()
+{
+    typedef kernel_functions::Exp<Params> Kernel_exp_t;
+    typedef kernel_functions::MaternThreeHalfs<Params> Kernel_mat_3_t;
+    typedef kernel_functions::MaternFiveHalfs<Params> Kernel_mat_5_t;
+    typedef kernel_functions::SquaredExpARD<Params> Kernel_sq_exp_ard_t;
+
+    typedef mean_functions::NullFunction<Params> Mean_null_t;
+    typedef mean_functions::MeanConstant<Params> Mean_const_t;
+    typedef mean_functions::MeanData<Params> Mean_data_t;
+    typedef mean_functions::MeanArchive<Params> Mean_arch_t;
+    typedef mean_functions::MeanFunctionARD<Params, MeanEval> Mean_ard_t;
+
+    typedef model::GP<Params, Kernel_exp_t, Mean_null_t> GP_exp_null_t;
+    typedef model::GP<Params, Kernel_exp_t, Mean_const_t> GP_exp_const_t;
+    typedef model::GP<Params, Kernel_exp_t, Mean_data_t> GP_exp_data_t;
+    typedef model::GP<Params, Kernel_exp_t, Mean_arch_t> GP_exp_arch_t;
+    typedef model::GP<Params, Kernel_exp_t, Mean_ard_t> GP_exp_ard_t;
+
+    typedef model::GP<Params, Kernel_mat_3_t, Mean_null_t> GP_mat3_null_t;
+    typedef model::GP<Params, Kernel_mat_3_t, Mean_const_t> GP_mat3_const_t;
+    typedef model::GP<Params, Kernel_mat_3_t, Mean_data_t> GP_mat3_data_t;
+    typedef model::GP<Params, Kernel_mat_3_t, Mean_arch_t> GP_mat3_arch_t;
+    typedef model::GP<Params, Kernel_mat_3_t, Mean_ard_t> GP_mat3_ard_t;
+
+    typedef model::GP<Params, Kernel_mat_5_t, Mean_null_t> GP_mat5_null_t;
+    typedef model::GP<Params, Kernel_mat_5_t, Mean_const_t> GP_mat5_const_t;
+    typedef model::GP<Params, Kernel_mat_5_t, Mean_data_t> GP_mat5_data_t;
+    typedef model::GP<Params, Kernel_mat_5_t, Mean_arch_t> GP_mat5_arch_t;
+    typedef model::GP<Params, Kernel_mat_5_t, Mean_ard_t> GP_mat5_ard_t;
+
+    typedef model::GP<Params, Kernel_sq_exp_ard_t, Mean_null_t> GP_sqexpard_null_t;
+    typedef model::GP<Params, Kernel_sq_exp_ard_t, Mean_const_t> GP_sqexpard_const_t;
+    typedef model::GP<Params, Kernel_sq_exp_ard_t, Mean_data_t> GP_sqexpard_data_t;
+    typedef model::GP<Params, Kernel_sq_exp_ard_t, Mean_arch_t> GP_sqexpard_arch_t;
+    typedef model::GP<Params, Kernel_sq_exp_ard_t, Mean_ard_t> GP_sqexpard_ard_t;
+
+    typedef model::GPAuto<Params, Kernel_sq_exp_ard_t, Mean_null_t> GPAuto_sqexpard_null_t;
+    typedef model::GPAuto<Params, Kernel_sq_exp_ard_t, Mean_const_t> GPAuto_sqexpard_const_t;
+    typedef model::GPAuto<Params, Kernel_sq_exp_ard_t, Mean_data_t> GPAuto_sqexpard_data_t;
+    typedef model::GPAuto<Params, Kernel_sq_exp_ard_t, Mean_arch_t> GPAuto_sqexpard_arch_t;
+    typedef model::GPAuto<Params, Kernel_sq_exp_ard_t, Mean_ard_t> GPAuto_sqexpard_ard_t;
+
+    typedef model::GPAutoMean<Params, Kernel_sq_exp_ard_t, Mean_ard_t> GPAutoMean_sqexpard_ard_t;
+    
+    typedef acquisition_functions::UCB<Params, GP_exp_null_t> Acqui_ucb_GP_exp_null_t;
+    typedef acquisition_functions::UCB<Params, GP_exp_const_t> Acqui_ucb_GP_exp_const_t;
+    typedef acquisition_functions::UCB<Params, GP_exp_data_t> Acqui_ucb_GP_exp_data_t;
+    typedef acquisition_functions::UCB<Params, GP_exp_arch_t> Acqui_ucb_GP_exp_arch_t;
+    typedef acquisition_functions::UCB<Params, GP_exp_ard_t> Acqui_ucb_GP_exp_ard_t;
+
+    typedef acquisition_functions::UCB<Params, GP_mat3_null_t> Acqui_ucb_GP_mat3_null_t;
+    typedef acquisition_functions::UCB<Params, GP_mat3_const_t> Acqui_ucb_GP_mat3_const_t;
+    typedef acquisition_functions::UCB<Params, GP_mat3_data_t> Acqui_ucb_GP_mat3_data_t;
+    typedef acquisition_functions::UCB<Params, GP_mat3_arch_t> Acqui_ucb_GP_mat3_arch_t;
+    typedef acquisition_functions::UCB<Params, GP_mat3_ard_t> Acqui_ucb_GP_mat3_ard_t;
+
+    typedef acquisition_functions::UCB<Params, GP_mat5_null_t> Acqui_ucb_GP_mat5_null_t;
+    typedef acquisition_functions::UCB<Params, GP_mat5_const_t> Acqui_ucb_GP_mat5_const_t;
+    typedef acquisition_functions::UCB<Params, GP_mat5_data_t> Acqui_ucb_GP_mat5_data_t;
+    typedef acquisition_functions::UCB<Params, GP_mat5_arch_t> Acqui_ucb_GP_mat5_arch_t;
+    typedef acquisition_functions::UCB<Params, GP_mat5_ard_t> Acqui_ucb_GP_mat5_ard_t;
+
+    typedef acquisition_functions::UCB<Params, GP_sqexpard_null_t> Acqui_ucb_GP_sqexpard_null_t;
+    typedef acquisition_functions::UCB<Params, GP_sqexpard_const_t> Acqui_ucb_GP_sqexpard_const_t;
+    typedef acquisition_functions::UCB<Params, GP_sqexpard_data_t> Acqui_ucb_GP_sqexpard_data_t;
+    typedef acquisition_functions::UCB<Params, GP_sqexpard_arch_t> Acqui_ucb_GP_sqexpard_arch_t;
+    typedef acquisition_functions::UCB<Params, GP_sqexpard_ard_t> Acqui_ucb_GP_sqexpard_ard_t;
+    
+    typedef acquisition_functions::UCB<Params, GPAuto_sqexpard_null_t> Acqui_ucb_GPAuto_sqexpard_null_t;
+    typedef acquisition_functions::UCB<Params, GPAuto_sqexpard_const_t> Acqui_ucb_GPAuto_sqexpard_const_t;
+    typedef acquisition_functions::UCB<Params, GPAuto_sqexpard_data_t> Acqui_ucb_GPAuto_sqexpard_data_t;
+    typedef acquisition_functions::UCB<Params, GPAuto_sqexpard_arch_t> Acqui_ucb_GPAuto_sqexpard_arch_t;
+    typedef acquisition_functions::UCB<Params, GPAuto_sqexpard_ard_t> Acqui_ucb_GPAuto_sqexpard_ard_t;
+
+    typedef acquisition_functions::UCB<Params, GPAutoMean_sqexpard_ard_t> Acqui_ucb_GPAutoMean_sqexpard_ard_t;
+
+    typedef acquisition_functions::GP_UCB<Params, GP_exp_null_t> Acqui_gp_ucb_GP_exp_null_t;
+    typedef acquisition_functions::GP_UCB<Params, GP_exp_const_t> Acqui_gp_ucb_GP_exp_const_t;
+    typedef acquisition_functions::GP_UCB<Params, GP_exp_data_t> Acqui_gp_ucb_GP_exp_data_t;
+    typedef acquisition_functions::GP_UCB<Params, GP_exp_arch_t> Acqui_gp_ucb_GP_exp_arch_t;
+    typedef acquisition_functions::GP_UCB<Params, GP_exp_ard_t> Acqui_gp_ucb_GP_exp_ard_t;
+
+    typedef acquisition_functions::GP_UCB<Params, GP_mat3_null_t> Acqui_gp_ucb_GP_mat3_null_t;
+    typedef acquisition_functions::GP_UCB<Params, GP_mat3_const_t> Acqui_gp_ucb_GP_mat3_const_t;
+    typedef acquisition_functions::GP_UCB<Params, GP_mat3_data_t> Acqui_gp_ucb_GP_mat3_data_t;
+    typedef acquisition_functions::GP_UCB<Params, GP_mat3_arch_t> Acqui_gp_ucb_GP_mat3_arch_t;
+    typedef acquisition_functions::GP_UCB<Params, GP_mat3_ard_t> Acqui_gp_ucb_GP_mat3_ard_t;
+
+    typedef acquisition_functions::GP_UCB<Params, GP_mat5_null_t> Acqui_gp_ucb_GP_mat5_null_t;
+    typedef acquisition_functions::GP_UCB<Params, GP_mat5_const_t> Acqui_gp_ucb_GP_mat5_const_t;
+    typedef acquisition_functions::GP_UCB<Params, GP_mat5_data_t> Acqui_gp_ucb_GP_mat5_data_t;
+    typedef acquisition_functions::GP_UCB<Params, GP_mat5_arch_t> Acqui_gp_ucb_GP_mat5_arch_t;
+    typedef acquisition_functions::GP_UCB<Params, GP_mat5_ard_t> Acqui_gp_ucb_GP_mat5_ard_t;
+
+    typedef acquisition_functions::GP_UCB<Params, GP_sqexpard_null_t> Acqui_gp_ucb_GP_sqexpard_null_t;
+    typedef acquisition_functions::GP_UCB<Params, GP_sqexpard_const_t> Acqui_gp_ucb_GP_sqexpard_const_t;
+    typedef acquisition_functions::GP_UCB<Params, GP_sqexpard_data_t> Acqui_gp_ucb_GP_sqexpard_data_t;
+    typedef acquisition_functions::GP_UCB<Params, GP_sqexpard_arch_t> Acqui_gp_ucb_GP_sqexpard_arch_t;
+    typedef acquisition_functions::GP_UCB<Params, GP_sqexpard_ard_t> Acqui_gp_ucb_GP_sqexpard_ard_t;
+    
+    typedef acquisition_functions::GP_UCB<Params, GPAuto_sqexpard_null_t> Acqui_gp_ucb_GPAuto_sqexpard_null_t;
+    typedef acquisition_functions::GP_UCB<Params, GPAuto_sqexpard_const_t> Acqui_gp_ucb_GPAuto_sqexpard_const_t;
+    typedef acquisition_functions::GP_UCB<Params, GPAuto_sqexpard_data_t> Acqui_gp_ucb_GPAuto_sqexpard_data_t;
+    typedef acquisition_functions::GP_UCB<Params, GPAuto_sqexpard_arch_t> Acqui_gp_ucb_GPAuto_sqexpard_arch_t;
+    typedef acquisition_functions::GP_UCB<Params, GPAuto_sqexpard_ard_t> Acqui_gp_ucb_GPAuto_sqexpard_ard_t;
+
+    typedef acquisition_functions::GP_UCB<Params, GPAutoMean_sqexpard_ard_t> Acqui_gp_ucb_GPAutoMean_sqexpard_ard_t;
+
+    typedef inner_optimization::Random<Params> In_opt_random_t;
+    typedef inner_optimization::ExhaustiveSearch<Params> In_opt_ex_search_t;
+    typedef inner_optimization::Cmaes<Params> In_opt_cmaes_t;
+
+    typedef init_functions::NoInit<Params> Init_no_init_t;
+    typedef init_functions::RandomSampling<Params> Init_random_t;
+    typedef init_functions::RandomSamplingGrid<Params> Init_random_grid_init_t;
+    typedef init_functions::GridSampling<Params> Init_grid_t;
+
+    typedef boost::fusion::vector<stat::Acquisitions<Params>> Stat_t;
+    typedef boost::fusion::vector<stopping_criterion::MaxIterations<Params>, stopping_criterion::MaxPredictedValue<Params>> Stop_t;
+
+    BOptimizer<Params, model_fun<GP_exp_null_t>, acq_fun<Acqui_ucb_GP_exp_null_t>, inneropt_fun<In_opt_random_t>, init_fun<Init_no_init_t>, stat_fun<Stat_t>, stop_fun<Stop_t>> opt_1;
+    opt_1.optimize(StateEval());
+    opt_1.best_observation();
+    opt_1.best_sample();
+    opt_1.optimize(StateEval(), Average(), true);
+    opt_1.best_observation(Average());
+    opt_1.best_sample(Average());
+
+    return 0;
+}

--- a/src/tests/all_combinations.cpp
+++ b/src/tests/all_combinations.cpp
@@ -231,5 +231,13 @@ int main()
     opt_1.best_observation(Average());
     opt_1.best_sample(Average());
 
+    BOptimizer<Params, model_fun<GPAutoMean_sqexpard_ard_t>, acq_fun<Acqui_gp_ucb_GPAutoMean_sqexpard_ard_t>, inneropt_fun<In_opt_cmaes_t>, init_fun<Init_random_grid_init_t>, stat_fun<Stat_t>, stop_fun<Stop_t>> opt_2;
+    opt_2.optimize(StateEval());
+    opt_2.best_observation();
+    opt_2.best_sample();
+    opt_2.optimize(StateEval(), Average(), true);
+    opt_2.best_observation(Average());
+    opt_2.best_sample(Average());
+
     return 0;
 }

--- a/src/tests/all_combinations.cpp
+++ b/src/tests/all_combinations.cpp
@@ -8,7 +8,7 @@ using namespace limbo;
 
 struct Params {
 
-   struct kf_exp {
+    struct kf_exp {
         BO_PARAM(double, sigma, 1);
     };
 
@@ -22,11 +22,11 @@ struct Params {
         BO_PARAM(double, l, 0.2);
     };
 
-     struct meanconstant {
+    struct meanconstant {
         BO_PARAM_VECTOR(double, constant, 0, 0);
     };
 
-    struct meanarchive{
+    struct meanarchive {
         BO_PARAM_STRING(filename, "missing");
     };
 
@@ -67,8 +67,7 @@ struct Params {
     };
 };
 
-struct MeanEval
-{
+struct MeanEval {
     MeanEval(size_t dim_out = 1) {}
 
     template <typename GP>
@@ -146,7 +145,7 @@ int main()
     typedef model::GPAuto<Params, Kernel_sq_exp_ard_t, Mean_ard_t> GPAuto_sqexpard_ard_t;
 
     typedef model::GPAutoMean<Params, Kernel_sq_exp_ard_t, Mean_ard_t> GPAutoMean_sqexpard_ard_t;
-    
+
     typedef acquisition_functions::UCB<Params, GP_exp_null_t> Acqui_ucb_GP_exp_null_t;
     typedef acquisition_functions::UCB<Params, GP_exp_const_t> Acqui_ucb_GP_exp_const_t;
     typedef acquisition_functions::UCB<Params, GP_exp_data_t> Acqui_ucb_GP_exp_data_t;
@@ -170,7 +169,7 @@ int main()
     typedef acquisition_functions::UCB<Params, GP_sqexpard_data_t> Acqui_ucb_GP_sqexpard_data_t;
     typedef acquisition_functions::UCB<Params, GP_sqexpard_arch_t> Acqui_ucb_GP_sqexpard_arch_t;
     typedef acquisition_functions::UCB<Params, GP_sqexpard_ard_t> Acqui_ucb_GP_sqexpard_ard_t;
-    
+
     typedef acquisition_functions::UCB<Params, GPAuto_sqexpard_null_t> Acqui_ucb_GPAuto_sqexpard_null_t;
     typedef acquisition_functions::UCB<Params, GPAuto_sqexpard_const_t> Acqui_ucb_GPAuto_sqexpard_const_t;
     typedef acquisition_functions::UCB<Params, GPAuto_sqexpard_data_t> Acqui_ucb_GPAuto_sqexpard_data_t;
@@ -202,7 +201,7 @@ int main()
     typedef acquisition_functions::GP_UCB<Params, GP_sqexpard_data_t> Acqui_gp_ucb_GP_sqexpard_data_t;
     typedef acquisition_functions::GP_UCB<Params, GP_sqexpard_arch_t> Acqui_gp_ucb_GP_sqexpard_arch_t;
     typedef acquisition_functions::GP_UCB<Params, GP_sqexpard_ard_t> Acqui_gp_ucb_GP_sqexpard_ard_t;
-    
+
     typedef acquisition_functions::GP_UCB<Params, GPAuto_sqexpard_null_t> Acqui_gp_ucb_GPAuto_sqexpard_null_t;
     typedef acquisition_functions::GP_UCB<Params, GPAuto_sqexpard_const_t> Acqui_gp_ucb_GPAuto_sqexpard_const_t;
     typedef acquisition_functions::GP_UCB<Params, GPAuto_sqexpard_data_t> Acqui_gp_ucb_GPAuto_sqexpard_data_t;

--- a/src/tests/bo_functions.cpp
+++ b/src/tests/bo_functions.cpp
@@ -217,25 +217,25 @@ void print_res(const T& r)
     for (auto x : r) {
         for (auto y : x.second) {
             std::cout << x.first << "\t =>"
-                      << " found :" << y.second(0) << " expected " << y.first(0)
+                      << " found :" << y.second << " expected " << y.first
                       << std::endl;
         }
-        std::vector<std::pair<Eigen::VectorXd, Eigen::VectorXd>>& v = x.second;
+        std::vector<std::pair<double, double>>& v = x.second;
         std::sort(v.begin(), v.end(),
-            [](const std::pair<Eigen::VectorXd, Eigen::VectorXd>& x1,
-                      const std::pair<Eigen::VectorXd, Eigen::VectorXd>& x2) {
+            [](const std::pair<double, double>& x1,
+                      const std::pair<double, double>& x2) {
                 // clang-format off
-                return x1.second(0) < x2.second(0);
+                return x1.second < x2.second;
                 // clang-format on
             });
-        double med = v[v.size() / 2].second(0);
-        if (fabs(v[0].first(0) - med) < 0.05)
+        double med = v[v.size() / 2].second;
+        if (fabs(v[0].first - med) < 0.05)
             std::cout << "[" << colors::green << "OK" << colors::reset << "] ";
         else
             std::cout << "[" << colors::red << "ERROR" << colors::reset << "] ";
         std::cout << colors::yellow << colors::bold << " -- " << x.first
                   << colors::reset << " ";
-        std::cout << "Median: " << med << " error :" << fabs(v[0].first(0) - med)
+        std::cout << "Median: " << med << " error :" << fabs(v[0].first - med)
                   << std::endl;
     }
 }
@@ -282,11 +282,11 @@ int main(int argc, char** argv)
     typedef BOptimizer<Params> Opt_t;
 
 #ifdef USE_TBB
-    typedef tbb::concurrent_hash_map<std::string, std::vector<std::pair<Eigen::VectorXd, Eigen::VectorXd>>>
+    typedef tbb::concurrent_hash_map<std::string, std::vector<std::pair<double, double>>>
         res_t;
 #else
     typedef std::map<std::string,
-        std::vector<std::pair<Eigen::VectorXd, Eigen::VectorXd>>>
+        std::vector<std::pair<double, double>>>
         res_t;
 #endif
     res_t results;
@@ -297,7 +297,7 @@ int main(int argc, char** argv)
                 Opt_t opt;
                 opt.optimize(Sphere());
                 Eigen::Vector2d s_val(0.5, 0.5);
-                Eigen::VectorXd x_opt = Sphere()(s_val);
+                double x_opt = NoReward()(Sphere()(s_val));
                 add_to_results("Sphere", results, std::make_pair(x_opt, opt.best_observation()));
             // clang-format on
         });
@@ -308,7 +308,7 @@ int main(int argc, char** argv)
                 Opt_t opt;
                 opt.optimize(Ellipsoid());
                 Eigen::Vector2d s_val(0.5, 0.5);
-                Eigen::VectorXd x_opt = Ellipsoid()(s_val);
+                double x_opt = NoReward()(Ellipsoid()(s_val));
                 add_to_results("Ellipsoid", results, std::make_pair(x_opt, opt.best_observation()));
             // clang-format on
         });
@@ -319,7 +319,7 @@ int main(int argc, char** argv)
                 Opt_t opt;
                 opt.optimize(Rastrigin());
                 Eigen::Vector4d s_val(0, 0, 0, 0);
-                Eigen::VectorXd x_opt = Rastrigin()(s_val);
+                double x_opt = NoReward()(Rastrigin()(s_val));
                 add_to_results("Rastrigin", results, std::make_pair(x_opt, opt.best_observation()));
             // clang-format on
         });
@@ -331,7 +331,7 @@ int main(int argc, char** argv)
                 opt.optimize(Hartman3());
                 // double s_max = 3.86278;
                 Eigen::Vector3d s_val(0.114614, 0.555549, 0.852547);
-                Eigen::VectorXd x_opt = Hartman3()(s_val);
+                double x_opt = NoReward()(Hartman3()(s_val));
                 add_to_results("Hartman 3", results, std::make_pair(x_opt, opt.best_observation()));
             // clang-format on
         });
@@ -344,7 +344,7 @@ int main(int argc, char** argv)
                 Eigen::Matrix<double, 6, 1> s_val;
                 s_val << 0.20169, 0.150011, 0.476874, 0.275332, 0.311652, 0.6573;
                 //double s_max = 3.32237;
-                Eigen::VectorXd x_opt = Hartman6()(s_val);
+                double x_opt = NoReward()(Hartman6()(s_val));
                 add_to_results("Hartman 6", results, std::make_pair(x_opt, opt.best_observation()));
             // clang-format on
         });
@@ -356,7 +356,7 @@ int main(int argc, char** argv)
                 opt.optimize(GoldenPrice());
                 //    double s_max = -log(3);
                 Eigen::Vector2d s_val(0.5, 0.25);
-                Eigen::VectorXd x_opt = GoldenPrice()(s_val);
+                double x_opt = NoReward()(GoldenPrice()(s_val));
                 add_to_results("Golden Price", results, std::make_pair(x_opt, opt.best_observation()));
             // clang-format on
         });

--- a/src/tests/bo_functions.cpp
+++ b/src/tests/bo_functions.cpp
@@ -203,9 +203,6 @@ struct Params {
 
     struct cmaes : public defaults::cmaes {
     };
-
-    struct meanconstant : public defaults::meanconstant {
-    };
 };
 
 // BO_DECLARE_DYN_PARAM(double, Params::meanconstant, constant);

--- a/src/tests/bo_functions.cpp
+++ b/src/tests/bo_functions.cpp
@@ -297,7 +297,7 @@ int main(int argc, char** argv)
                 Opt_t opt;
                 opt.optimize(Sphere());
                 Eigen::Vector2d s_val(0.5, 0.5);
-                double x_opt = NoReward()(Sphere()(s_val));
+                double x_opt = FirstElem()(Sphere()(s_val));
                 add_to_results("Sphere", results, std::make_pair(x_opt, opt.best_observation()));
             // clang-format on
         });
@@ -308,7 +308,7 @@ int main(int argc, char** argv)
                 Opt_t opt;
                 opt.optimize(Ellipsoid());
                 Eigen::Vector2d s_val(0.5, 0.5);
-                double x_opt = NoReward()(Ellipsoid()(s_val));
+                double x_opt = FirstElem()(Ellipsoid()(s_val));
                 add_to_results("Ellipsoid", results, std::make_pair(x_opt, opt.best_observation()));
             // clang-format on
         });
@@ -319,7 +319,7 @@ int main(int argc, char** argv)
                 Opt_t opt;
                 opt.optimize(Rastrigin());
                 Eigen::Vector4d s_val(0, 0, 0, 0);
-                double x_opt = NoReward()(Rastrigin()(s_val));
+                double x_opt = FirstElem()(Rastrigin()(s_val));
                 add_to_results("Rastrigin", results, std::make_pair(x_opt, opt.best_observation()));
             // clang-format on
         });
@@ -331,7 +331,7 @@ int main(int argc, char** argv)
                 opt.optimize(Hartman3());
                 // double s_max = 3.86278;
                 Eigen::Vector3d s_val(0.114614, 0.555549, 0.852547);
-                double x_opt = NoReward()(Hartman3()(s_val));
+                double x_opt = FirstElem()(Hartman3()(s_val));
                 add_to_results("Hartman 3", results, std::make_pair(x_opt, opt.best_observation()));
             // clang-format on
         });
@@ -344,7 +344,7 @@ int main(int argc, char** argv)
                 Eigen::Matrix<double, 6, 1> s_val;
                 s_val << 0.20169, 0.150011, 0.476874, 0.275332, 0.311652, 0.6573;
                 //double s_max = 3.32237;
-                double x_opt = NoReward()(Hartman6()(s_val));
+                double x_opt = FirstElem()(Hartman6()(s_val));
                 add_to_results("Hartman 6", results, std::make_pair(x_opt, opt.best_observation()));
             // clang-format on
         });
@@ -356,7 +356,7 @@ int main(int argc, char** argv)
                 opt.optimize(GoldenPrice());
                 //    double s_max = -log(3);
                 Eigen::Vector2d s_val(0.5, 0.25);
-                double x_opt = NoReward()(GoldenPrice()(s_val));
+                double x_opt = FirstElem()(GoldenPrice()(s_val));
                 add_to_results("Golden Price", results, std::make_pair(x_opt, opt.best_observation()));
             // clang-format on
         });

--- a/src/tests/test_macros.cpp
+++ b/src/tests/test_macros.cpp
@@ -11,7 +11,7 @@ struct Params {
         BO_DYN_PARAM(int, b);
         BO_PARAM_ARRAY(double, c, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0);
         BO_PARAM_VECTOR(double, d, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0);
-        BO_STRING(e, "e");
+        BO_PARAM_STRING(e, "e");
     };
 };
 

--- a/src/tests/wscript
+++ b/src/tests/wscript
@@ -33,3 +33,9 @@ def build(bld):
                       target='test_macros',
                       uselib='BOOST EIGEN TBB',
                       use='limbo')
+    obj = bld.program(features='cxx',
+                      source='all_combinations.cpp',
+                      includes='. .. ../../',
+                      target='all_combinations',
+                      uselib='BOOST EIGEN TBB',
+                      use='limbo')


### PR DESCRIPTION
Still have to add examples and tests (I'll be adding tests with every acquisition function/stopping criterion/inner optimization fuction, to check that I didn't broke any), but I made the pull request so you can start looking at the code.
I was thinking whether we should specify the default reward function as NoReward everywhere (that means every function/class that receives a  Reward function as argument), or just on the BOptimizer functions. I have a little dilema with this:
At first, it seemed to me that it would be best for the user to have it defaulted everywhere, but then I saw that this functor is always passed from the BOptimizer to the rest of the classes, and that having it as default could introduce difficult to detect bugs (e.g. if we forget to pass the functor somewhere, it would use the default, instead of what the user provided, and there won't be any compilation errors or anything).
Would like to hear your thoughts.
In the next days I will add the examples of usage and tests.
CC: @Aneoshun @costashatz @jbmouret 