### PR TITLE
Fixed missing includes of the standard library (vector & iostream)

### DIFF
--- a/src/limbo/init/random_sampling.hpp
+++ b/src/limbo/init/random_sampling.hpp
@@ -1,6 +1,7 @@
 #ifndef LIMBO_INIT_RANDOM_SAMPLING_HPP
 #define LIMBO_INIT_RANDOM_SAMPLING_HPP
 
+#include <iostream>
 #include <Eigen/Core>
 
 #include <limbo/tools/rand.hpp>

--- a/src/limbo/init/random_sampling.hpp
+++ b/src/limbo/init/random_sampling.hpp
@@ -2,6 +2,7 @@
 #define LIMBO_INIT_RANDOM_SAMPLING_HPP
 
 #include <iostream>
+
 #include <Eigen/Core>
 
 #include <limbo/tools/rand.hpp>

--- a/src/limbo/model/gp.hpp
+++ b/src/limbo/model/gp.hpp
@@ -4,6 +4,7 @@
 #include <iostream>
 #include <cassert>
 #include <limits>
+#include <vector>
 
 #include <Eigen/Core>
 #include <Eigen/LU>


### PR DESCRIPTION
Very minor fix required for clang. I suppose this is because of yesterday's patch by Federico.