### PR TITLE
Parameters Improvements

### DIFF
--- a/src/examples/mono_dim.cpp
+++ b/src/examples/mono_dim.cpp
@@ -9,32 +9,35 @@ using namespace limbo;
 
 BO_PARAMS(std::cout,
           struct Params {
-              struct gp_ucb : public defaults::gp_ucb {
+              struct acqui_gpucb : public defaults::acqui_gpucb {
               };
 
-              struct cmaes : public defaults::cmaes {
+              struct opt_cmaes : public defaults::opt_cmaes {
               };
 
-              struct ucb {
+              struct acqui_ucb {
                   BO_PARAM(double, alpha, 0.1);
               };
 
-              struct kf_maternfivehalfs {
+              struct kernel_maternfivehalfs {
                   BO_PARAM(double, sigma, 1);
                   BO_PARAM(double, l, 0.2);
               };
 
-              struct boptimizer {
-                  BO_PARAM(double, noise, 0.001);
-                  BO_PARAM(bool, stats_enabled, true);
+              struct bayes_opt_bobase {
+                BO_PARAM(bool, stats_enabled, true);
               };
 
-              struct init {
-                  BO_PARAM(int, nb_samples, 5);
+              struct bayes_opt_boptimizer {
+                  BO_PARAM(double, noise, 0.001);                  
               };
 
-              struct maxiterations {
-                  BO_PARAM(int, n_iterations, 20);
+              struct init_randomsampling {
+                  BO_PARAM(int, samples, 5);
+              };
+
+              struct stop_maxiterations {
+                  BO_PARAM(int, iterations, 20);
               };
           };)
 

--- a/src/examples/mono_dim.cpp
+++ b/src/examples/mono_dim.cpp
@@ -16,12 +16,12 @@ BO_PARAMS(std::cout,
               };
 
               struct ucb {
-                  BO_PARAM(float, alpha, 0.1);
+                  BO_PARAM(double, alpha, 0.1);
               };
 
               struct kf_maternfivehalfs {
-                  BO_PARAM(float, sigma, 1);
-                  BO_PARAM(float, l, 0.2);
+                  BO_PARAM(double, sigma, 1);
+                  BO_PARAM(double, l, 0.2);
               };
 
               struct boptimizer {

--- a/src/examples/obs_multi.cpp
+++ b/src/examples/obs_multi.cpp
@@ -15,8 +15,8 @@ struct Params {
     };
 
     struct kf_maternfivehalfs {
-        BO_PARAM(float, sigma, 1);
-        BO_PARAM(float, l, 0.2);
+        BO_PARAM(double, sigma, 1);
+        BO_PARAM(double, l, 0.2);
     };
 
     struct boptimizer {

--- a/src/examples/obs_multi.cpp
+++ b/src/examples/obs_multi.cpp
@@ -8,28 +8,31 @@
 using namespace limbo;
 
 struct Params {
-    struct gp_ucb : public defaults::gp_ucb {
+    struct acqui_gpucb : public defaults::acqui_gpucb {
     };
 
-    struct cmaes : public defaults::cmaes {
+    struct opt_cmaes : public defaults::opt_cmaes {
     };
 
-    struct kf_maternfivehalfs {
+    struct kernel_maternfivehalfs {
         BO_PARAM(double, sigma, 1);
         BO_PARAM(double, l, 0.2);
     };
 
-    struct boptimizer {
-        BO_PARAM(double, noise, 0.001);
+    struct bayes_opt_bobase {
         BO_PARAM(bool, stats_enabled, true);
     };
 
-    struct init {
-        BO_PARAM(int, nb_samples, 5);
+    struct bayes_opt_boptimizer {
+        BO_PARAM(double, noise, 0.001);
     };
 
-    struct maxiterations {
-        BO_PARAM(int, n_iterations, 20);
+    struct init_randomsampling {
+        BO_PARAM(int, samples, 5);
+    };
+
+    struct stop_maxiterations {
+        BO_PARAM(int, iterations, 20);
     };
 };
 

--- a/src/examples/obs_multi_auto_mean.cpp
+++ b/src/examples/obs_multi_auto_mean.cpp
@@ -8,36 +8,35 @@
 using namespace limbo;
 
 struct Params {
-    struct gp_auto_mean {
-        BO_PARAM(int, n_rprop, 100);
-        BO_PARAM(int, rprop_restart, 10);
+    struct opt_cmaes : public defaults::opt_cmaes {
     };
 
-    struct cmaes : public defaults::cmaes {
+    struct opt_rprop : public defaults::opt_rprop {
     };
 
-    struct rprop : public defaults::rprop {
-    };
-
-    struct kf_maternfivehalfs {
+    struct kernel_maternfivehalfs {
         BO_PARAM(double, sigma, 1);
         BO_PARAM(double, l, 0.2);
     };
 
-    struct boptimizer {
+    struct bayes_opt_bobase {
+        BO_PARAM(bool, stats_enabled, true);
+    };
+
+    struct bayes_opt_boptimizer {
         BO_PARAM(double, noise, 0.001);
         BO_PARAM(bool, stats_enabled, true);
     };
 
-    struct init {
-        BO_PARAM(int, nb_samples, 5);
+    struct init_randomsampling {
+        BO_PARAM(int, samples, 5);
     };
 
-    struct maxiterations {
-        BO_PARAM(int, n_iterations, 100);
+    struct stop_maxiterations {
+        BO_PARAM(int, iterations, 100);
     };
 
-    struct parallel_repeater : defaults::parallel_repeater {
+    struct opt_parallelrepeater : defaults::opt_parallelrepeater {
     };
 };
 

--- a/src/examples/obs_multi_auto_mean.cpp
+++ b/src/examples/obs_multi_auto_mean.cpp
@@ -20,8 +20,8 @@ struct Params {
     };
 
     struct kf_maternfivehalfs {
-        BO_PARAM(float, sigma, 1);
-        BO_PARAM(float, l, 0.2);
+        BO_PARAM(double, sigma, 1);
+        BO_PARAM(double, l, 0.2);
     };
 
     struct boptimizer {

--- a/src/examples/parego.cpp
+++ b/src/examples/parego.cpp
@@ -3,37 +3,34 @@
 using namespace limbo;
 
 struct Params {
-    struct boptimizer {
-        BO_PARAM(double, noise, 0.005);
-        BO_PARAM(bool, stats_enabled, true);
-    };
-
-    struct init {
-        BO_PARAM(int, nb_samples, 21);
+    struct init_randomsampling {
+        BO_PARAM(int, samples, 21);
         // calandra: number of dimensions * 5
         // knowles : 11 * dim - 1
     };
 
-    struct maxiterations {
-        BO_PARAM(int, n_iterations, 30);
+    struct stop_maxiterations {
+        BO_PARAM(int, iterations, 30);
     };
 
-    struct ucb : public defaults::ucb {
+    struct acqui_ucb : public defaults::acqui_ucb {
     };
 
-    struct gp_ucb : public defaults::gp_ucb {
+    struct acqui_gpucb : public defaults::acqui_gpucb {
     };
 
-    struct cmaes : public defaults::cmaes {
+    struct opt_cmaes : public defaults::opt_cmaes {
     };
 
-    struct gp_auto : public defaults::gp_auto {
+    struct mean_constant : public defaults::mean_constant {
     };
 
-    struct meanconstant : public defaults::meanconstant {
+    struct bayes_opt_bobase {
+        BO_PARAM(bool, stats_enabled, true);
     };
 
-    struct parego : public defaults::parego {
+    struct bayes_opt_parego : public defaults::bayes_opt_parego {
+        BO_PARAM(double, noise, 0.005);
     };
 };
 
@@ -85,7 +82,7 @@ int main()
     // typedef model::GP<Params, kernel_t, mean_t> gp_t;
     // typedef acquisition_functions::UCB<Params, gp_t> ucb_t;
     // Parego<Params, model_fun<gp_t>, acq_fun<ucb_t> > opt;
-    Parego<Params> opt;
+    bayes_opt::Parego<Params> opt;
     opt.optimize(mop2());
 
     std::cout << "optimization done" << std::endl;

--- a/src/limbo/acqui/gp_ucb.hpp
+++ b/src/limbo/acqui/gp_ucb.hpp
@@ -6,13 +6,11 @@
 #include <limbo/tools/macros.hpp>
 
 namespace limbo {
-
     namespace defaults {
-        struct gp_ucb {
+        struct acqui_gpucb {
             BO_PARAM(double, delta, 0.001);
         };
     }
-
     namespace acqui {
         template <typename Params, typename Model>
         class GP_UCB {
@@ -20,7 +18,7 @@ namespace limbo {
             GP_UCB(const Model& model, int iteration) : _model(model)
             {
                 double t3 = pow(iteration, 3.0);
-                static constexpr double delta3 = Params::gp_ucb::delta() * 3;
+                static constexpr double delta3 = Params::acqui_gpucb::delta() * 3;
                 static constexpr double pi2 = M_PI * M_PI;
                 _beta = sqrtf(2.0 * log(t3 * pi2 / delta3));
             }

--- a/src/limbo/acqui/gp_ucb.hpp
+++ b/src/limbo/acqui/gp_ucb.hpp
@@ -9,7 +9,7 @@ namespace limbo {
 
     namespace defaults {
         struct gp_ucb {
-            BO_PARAM(float, delta, 0.001);
+            BO_PARAM(double, delta, 0.001);
         };
     }
 

--- a/src/limbo/acqui/ucb.hpp
+++ b/src/limbo/acqui/ucb.hpp
@@ -6,13 +6,11 @@
 #include <limbo/tools/macros.hpp>
 
 namespace limbo {
-
     namespace defaults {
-        struct ucb {
+        struct acqui_ucb {
             BO_PARAM(double, alpha, 0.5);
         };
     }
-
     namespace acqui {
         template <typename Params, typename Model>
         class UCB {
@@ -29,7 +27,7 @@ namespace limbo {
                 Eigen::VectorXd mu;
                 double sigma;
                 std::tie(mu, sigma) = _model.query(v);
-                return (afun(mu) + Params::ucb::alpha() * sqrt(sigma));
+                return (afun(mu) + Params::acqui_ucb::alpha() * sqrt(sigma));
             }
 
         protected:

--- a/src/limbo/acqui/ucb.hpp
+++ b/src/limbo/acqui/ucb.hpp
@@ -9,7 +9,7 @@ namespace limbo {
 
     namespace defaults {
         struct ucb {
-            BO_PARAM(float, alpha, 0.5);
+            BO_PARAM(double, alpha, 0.5);
         };
     }
 

--- a/src/limbo/bayes_opt/bo_base.hpp
+++ b/src/limbo/bayes_opt/bo_base.hpp
@@ -15,6 +15,7 @@
 #include <Eigen/Core>
 
 // we need everything to have the defaults
+#include <limbo/tools/macros.hpp>
 #include <limbo/stop/chain_criteria.hpp>
 #include <limbo/stop/max_iterations.hpp>
 #include <limbo/stat/samples.hpp>
@@ -29,7 +30,11 @@
 #include <limbo/init/random_sampling.hpp>
 
 namespace limbo {
-
+    namespace defaults {
+        struct bayes_opt_bobase {
+            BO_PARAM(bool, stats_enabled, true);            
+        };
+    }
     template <typename BO, typename AggregatorFunction>
     struct RefreshStat_f {
         RefreshStat_f(BO& bo, const AggregatorFunction& afun, bool blacklisted)
@@ -125,7 +130,7 @@ namespace limbo {
             BoBase(const BoBase& other) = delete;
             BoBase& operator=(const BoBase& other) = delete;
 
-            bool stats_enabled() const { return Params::boptimizer::stats_enabled(); }
+            bool stats_enabled() const { return Params::bayes_opt_bobase::stats_enabled(); }
 
             const std::string& res_dir() const { return _res_dir; }
 
@@ -183,7 +188,7 @@ namespace limbo {
 
             void _make_res_dir()
             {
-                if (!Params::boptimizer::stats_enabled())
+                if (!Params::bayes_opt_bobase::stats_enabled())
                     return;
                 _res_dir = tools::hostname() + "_" + tools::date() + "_" + tools::getpid();
                 boost::filesystem::path my_path(_res_dir);

--- a/src/limbo/bayes_opt/boptimizer.hpp
+++ b/src/limbo/bayes_opt/boptimizer.hpp
@@ -10,9 +10,15 @@
 
 #include <Eigen/Core>
 
+#include <limbo/tools/macros.hpp>
 #include <limbo/bayes_opt/bo_base.hpp>
 
 namespace limbo {
+    namespace defaults {
+        struct bayes_opt_boptimizer {
+            BO_PARAM(double, noise, 1e-6);
+        };
+    }
     namespace bayes_opt {
 
         template <class Params, class A1 = boost::parameter::void_,
@@ -59,7 +65,7 @@ namespace limbo {
                 this->_init(sfun, afun, reset);
 
                 if (!this->_observations.empty())
-                        _model.compute(this->_samples, this->_observations, Params::boptimizer::noise(), this->_bl_samples);
+                        _model.compute(this->_samples, this->_observations, Params::bayes_opt_boptimizer::noise(), this->_bl_samples);
                 
                 acqui_optimizer_t acqui_optimizer;
 
@@ -98,7 +104,7 @@ namespace limbo {
                     std::cout << " best:" << afun(this->best_observation(afun)) << std::endl;
 
                     if (!this->_observations.empty())
-                        _model.compute(this->_samples, this->_observations, Params::boptimizer::noise(), this->_bl_samples);
+                        _model.compute(this->_samples, this->_observations, Params::bayes_opt_boptimizer::noise(), this->_bl_samples);
 
                     this->_current_iteration++;
                     this->_total_iterations++;

--- a/src/limbo/bayes_opt/ehvi.hpp
+++ b/src/limbo/bayes_opt/ehvi.hpp
@@ -6,10 +6,17 @@
 #include <ehvi/ehvi_calculations.h>
 #include <ehvi/ehvi_sliceupdate.h>
 
+#include <limbo/tools/macros.hpp>
 #include <limbo/bayes_opt/bo_multi.hpp>
 #include <limbo/acqui/ehvi.hpp>
 
 namespace limbo {
+    namespace defaults {
+        struct bayes_opt_ehvi {
+            BO_PARAM(double, x_ref, -11);
+            BO_PARAM(double, y_ref, -11);
+        };
+    }
     namespace bayes_opt {
         template <class Params, class A2 = boost::parameter::void_,
             class A3 = boost::parameter::void_, class A4 = boost::parameter::void_,
@@ -49,7 +56,7 @@ namespace limbo {
 
                     auto acqui = acqui::Ehvi<Params, model_t>(
                         this->_models, pop,
-                        Eigen::Vector3d(Params::ehvi::x_ref(), Params::ehvi::y_ref(), 0));
+                        Eigen::Vector3d(Params::bayes_opt_ehvi::x_ref(), Params::bayes_opt_ehvi::y_ref(), 0));
 
                     // maximize with CMA-ES
                     typedef std::pair<Eigen::VectorXd, double> pair_t;

--- a/src/limbo/bayes_opt/parego.hpp
+++ b/src/limbo/bayes_opt/parego.hpp
@@ -3,16 +3,16 @@
 
 #include <algorithm>
 
-#include <limbo/limbo.hpp>
+#include <limbo/tools/macros.hpp>
 #include <limbo/bayes_opt/bo_multi.hpp>
 
 namespace limbo {
     namespace defaults {
-        struct parego {
+        struct bayes_opt_parego {
+            BO_PARAM(double, noise, 1e-6);
             BO_PARAM(double, rho, 0.05);
         };
     }
-
     namespace bayes_opt {
 
         template <class Params, class A3 = boost::parameter::void_,
@@ -34,7 +34,7 @@ namespace limbo {
 
                 std::vector<double> scalarized = _scalarize_obs();
                 model_t model(EvalFunction::dim);
-                model.compute(this->_samples, scalarized, Params::boptimizer::noise());
+                model.compute(this->_samples, scalarized, Params::bayes_opt_parego::noise());
 
                 acqui_optimizer_t inner_optimization;
 
@@ -47,7 +47,7 @@ namespace limbo {
                               << " | new sample:" << new_sample.transpose() << " => "
                               << feval(new_sample).transpose() << std::endl;
                     scalarized = _scalarize_obs();
-                    model.compute(this->_samples, scalarized, Params::boptimizer::noise());
+                    model.compute(this->_samples, scalarized, Params::bayes_opt_parego::noise());
                     this->_update_stats(*this, FirstElem(), false);
                     this->_current_iteration++;
                     this->_total_iterations++;
@@ -70,7 +70,7 @@ namespace limbo {
                 for (auto x : this->_observations) {
                     double y = (lambda.array() * x.array()).maxCoeff();
                     double s = (lambda.array() * x.array()).sum();
-                    scalarized.push_back(y + Params::parego::rho() * s);
+                    scalarized.push_back(y + Params::bayes_opt_parego::rho() * s);
                 }
                 return scalarized;
             }

--- a/src/limbo/init/grid_sampling.hpp
+++ b/src/limbo/init/grid_sampling.hpp
@@ -3,10 +3,15 @@
 
 #include <Eigen/Core>
 
+#include <limbo/tools/macros.hpp>
+
 namespace limbo {
+    namespace defaults {
+        struct init_gridsampling {
+            BO_PARAM(int, bins, 5);
+        };
+    }
     namespace init {
-        // params:
-        //  -init::nb_bins
         template <typename Params>
         struct GridSampling {
             template <typename StateFunction, typename AggregatorFunction, typename Opt>
@@ -16,12 +21,12 @@ namespace limbo {
             }
 
         private:
-            // recursively explore all the dim_inensions
+            // recursively explore all the dimensions
             template <typename StateFunction, typename Opt>
             void _explore(int dim_in, const StateFunction& seval, const Eigen::VectorXd& current,
                 Opt& opt) const
             {
-                for (double x = 0; x <= 1.0f; x += 1.0f / (double)Params::init::nb_bins()) {
+                for (double x = 0; x <= 1.0f; x += 1.0f / (double)Params::init_gridsampling::bins()) {
                     Eigen::VectorXd point = current;
                     point[dim_in] = x;
                     if (dim_in == current.size() - 1) {

--- a/src/limbo/init/random_sampling.hpp
+++ b/src/limbo/init/random_sampling.hpp
@@ -3,18 +3,22 @@
 
 #include <Eigen/Core>
 
+#include <limbo/tools/macros.hpp>
 #include <limbo/tools/rand.hpp>
 
 namespace limbo {
+    namespace defaults {
+        struct init_randomsampling {
+            BO_PARAM(int, samples, 10);
+        };
+    }
     namespace init {
-        // initialize in [0,1] !
-        // params: init::nb_samples
         template <typename Params>
         struct RandomSampling {
             template <typename StateFunction, typename AggregatorFunction, typename Opt>
             void operator()(const StateFunction& seval, const AggregatorFunction&, Opt& opt) const
             {
-                for (int i = 0; i < Params::init::nb_samples(); i++) {
+                for (int i = 0; i < Params::init_randomsampling::samples(); i++) {
                     Eigen::VectorXd new_sample(StateFunction::dim_in);
                     for (int i = 0; i < StateFunction::dim_in; i++)
                         new_sample[i] = tools::rand<double>(0, 1);                 

--- a/src/limbo/init/random_sampling_grid.hpp
+++ b/src/limbo/init/random_sampling_grid.hpp
@@ -3,21 +3,25 @@
 
 #include <Eigen/Core>
 
+#include <limbo/tools/macros.hpp>
+
 namespace limbo {
+    namespace defaults {
+        struct init_randomsamplinggrid {
+            BO_PARAM(int, samples, 10);
+            BO_PARAM(int, bins, 5);
+        };
+    }
     namespace init {
-        // initialize in [0,1] !
-        // params:
-        //  -init::nb_bins
-        //  - init::nb_samples
         template <typename Params>
         struct RandomSamplingGrid {
             template <typename StateFunction, typename AggregatorFunction, typename Opt>
             void operator()(const StateFunction& seval, const AggregatorFunction&, Opt& opt) const
             {
-                for (int i = 0; i < Params::init::nb_samples(); i++) {
+                for (int i = 0; i < Params::init_randomsamplinggrid::samples(); i++) {
                     Eigen::VectorXd new_sample(StateFunction::dim_in);
                     for (size_t i = 0; i < StateFunction::dim_in; i++)
-                        new_sample[i] = int(((double)(Params::init::nb_bins() + 1) * rand()) / (RAND_MAX + 1.0)) / double(Params::init::nb_bins());
+                        new_sample[i] = int(((double)(Params::init_randomsamplinggrid::bins() + 1) * rand()) / (RAND_MAX + 1.0)) / double(Params::init_randomsamplinggrid::bins());
                     opt.add_new_sample(new_sample, seval(new_sample));
                 }
             }

--- a/src/limbo/kernel/exp.hpp
+++ b/src/limbo/kernel/exp.hpp
@@ -3,14 +3,21 @@
 
 #include <Eigen/Core>
 
+#include <limbo/tools/macros.hpp>
+
 namespace limbo {
+    namespace defaults {
+        struct kernel_exp {
+            BO_PARAM(double, sigma, 1);
+        };
+    }
     namespace kernel {
         template <typename Params>
         struct Exp {
             Exp(size_t dim = 1) {}
             double operator()(const Eigen::VectorXd& v1, const Eigen::VectorXd& v2) const
             {
-                double _sigma = Params::kf_exp::sigma();
+                double _sigma = Params::kernel_exp::sigma();
                 return (exp(-(1 / (2 * pow(_sigma, 2))) * pow((v1 - v2).norm(), 2)));
             }
         };

--- a/src/limbo/kernel/matern_five_halfs.hpp
+++ b/src/limbo/kernel/matern_five_halfs.hpp
@@ -3,7 +3,15 @@
 
 #include <Eigen/Core>
 
+#include <limbo/tools/macros.hpp>
+
 namespace limbo {
+    namespace defaults {
+        struct kernel_maternfivehalfs {
+            BO_PARAM(double, sigma, 1);
+            BO_PARAM(double, l, 1);
+        };
+    }
     namespace kernel {
         template <typename Params>
         struct MaternFiveHalfs {
@@ -12,7 +20,7 @@ namespace limbo {
             double operator()(const Eigen::VectorXd& v1, const Eigen::VectorXd& v2) const
             {
                 double d = (v1 - v2).norm();
-                return Params::kf_maternfivehalfs::sigma() * (1 + sqrt(5) * d / Params::kf_maternfivehalfs::l() + 5 * d * d / (3 * Params::kf_maternfivehalfs::l() * Params::kf_maternfivehalfs::l())) * exp(-sqrt(5) * d / Params::kf_maternfivehalfs::l());
+                return Params::kernel_maternfivehalfs::sigma() * (1 + sqrt(5) * d / Params::kernel_maternfivehalfs::l() + 5 * d * d / (3 * Params::kernel_maternfivehalfs::l() * Params::kernel_maternfivehalfs::l())) * exp(-sqrt(5) * d / Params::kernel_maternfivehalfs::l());
             }
         };
     }

--- a/src/limbo/kernel/matern_three_halfs.hpp
+++ b/src/limbo/kernel/matern_three_halfs.hpp
@@ -3,7 +3,15 @@
 
 #include <Eigen/Core>
 
+#include <limbo/tools/macros.hpp>
+
 namespace limbo {
+    namespace defaults {
+        struct kernel_maternthreehalfs {
+            BO_PARAM(double, sigma, 1);
+            BO_PARAM(double, l, 1);
+        };
+    }
     namespace kernel {
         template <typename Params>
         struct MaternThreeHalfs {
@@ -12,7 +20,7 @@ namespace limbo {
             double operator()(const Eigen::VectorXd& v1, const Eigen::VectorXd& v2) const
             {
                 double d = (v1 - v2).norm();
-                return Params::kf_maternthreehalfs::sigma() * (1 + sqrt(3) * d / Params::kf_maternthreehalfs::l()) * exp(-sqrt(3) * d / Params::kf_maternthreehalfs::l());
+                return Params::kernel_maternthreehalfs::sigma() * (1 + sqrt(3) * d / Params::kernel_maternthreehalfs::l()) * exp(-sqrt(3) * d / Params::kernel_maternthreehalfs::l());
             }
         };
     }

--- a/src/limbo/mean/constant.hpp
+++ b/src/limbo/mean/constant.hpp
@@ -3,17 +3,27 @@
 
 #include <Eigen/Core>
 
+#include <limbo/tools/macros.hpp>
+
 namespace limbo {
+    namespace defaults {
+        struct mean_constant {
+            BO_PARAM(double, constant, 1);
+        };
+    }
     namespace mean {
         template <typename Params>
         struct Constant {
-            Constant(size_t dim_out = 1) {}
+            Constant(size_t dim_out = 1) : _dim_out(dim_out) {}
 
             template <typename GP>
             Eigen::VectorXd operator()(const Eigen::VectorXd& v, const GP&) const
             {
-                return Params::meanconstant::constant();
+                return Eigen::VectorXd::Constant(_dim_out, Params::mean_constant::constant());
             }
+
+        protected:
+            size_t _dim_out;
         };
     }
 }

--- a/src/limbo/opt/cmaes.hpp
+++ b/src/limbo/opt/cmaes.hpp
@@ -13,16 +13,16 @@
 #include <cmaes/cmaes_interface.h>
 #include <cmaes/boundary_transformation.h>
 
+#include <limbo/tools/macros.hpp>
 #include <limbo/tools/parallel.hpp>
 
 namespace limbo {
     namespace defaults {
-        struct cmaes {
-            BO_PARAM(int, nrestarts, 1);
+        struct opt_cmaes {
+            BO_PARAM(int, restarts, 1);
             BO_PARAM(double, max_fun_evals, -1);
         };
     }
-
     namespace opt {
         template <typename Params>
         struct Cmaes {
@@ -32,7 +32,7 @@ namespace limbo {
             {
                 // Currrently cmaes does not support unbounded search
                 assert(bounded);
-                int nrestarts = Params::cmaes::nrestarts();
+                int nrestarts = Params::opt_cmaes::restarts();
                 size_t dim = f.param_size();
                 double incpopsize = 2;
                 cmaes_t evo;
@@ -59,9 +59,9 @@ namespace limbo {
                     fitvals = cmaes_init(&evo, dim, init_point, NULL, 0, lambda, NULL);
 
                     evo.countevals = countevals;
-                    evo.sp.stopMaxFunEvals = Params::cmaes::max_fun_evals() < 0
+                    evo.sp.stopMaxFunEvals = Params::opt_cmaes::max_fun_evals() < 0
                         ? (900.0 * (dim + 3.0) * (dim + 3.0))
-                        : Params::cmaes::max_fun_evals();
+                        : Params::opt_cmaes::max_fun_evals();
 
                     int pop_size = cmaes_Get(&evo, "popsize");
                     double** all_x_in_bounds = new double* [pop_size];

--- a/src/limbo/opt/grid_search.hpp
+++ b/src/limbo/opt/grid_search.hpp
@@ -5,7 +5,14 @@
 
 #include <Eigen/Core>
 
+#include <limbo/tools/macros.hpp>
+
 namespace limbo {
+   namespace defaults {
+        struct opt_gridsearch {
+            BO_PARAM(int, bins, 5);
+        };
+    }    
     namespace opt {
         template <typename Params>
         struct GridSearch {
@@ -22,7 +29,7 @@ namespace limbo {
             template <typename F>
             Eigen::VectorXd _inner_search(const F& f, int depth, const Eigen::VectorXd& current) const
             {
-                double step_size = 1.0 / (double)Params::grid_search::nb_pts();
+                double step_size = 1.0 / (double)Params::opt_gridsearch::bins();
                 double upper_lim = 1.0 + step_size;
 
                 double best_fit = -std::numeric_limits<double>::max();

--- a/src/limbo/opt/nlopt_grad.hpp
+++ b/src/limbo/opt/nlopt_grad.hpp
@@ -10,7 +10,14 @@
 
 #include <nlopt.hpp>
 
+#include <limbo/tools/macros.hpp>
+
 namespace limbo {
+   namespace defaults {
+        struct opt_nloptgrad {
+            BO_PARAM(int, iterations, 500);
+        };
+    }
     namespace opt {
         template <typename Params, nlopt::algorithm Algorithm>
         struct NLOptGrad {
@@ -25,7 +32,7 @@ namespace limbo {
                 std::vector<double> x(f.init().size());
                 Eigen::VectorXd::Map(&x[0], f.init().size()) = f.init();
 
-                opt.set_maxeval(Params::nlopt::iters());
+                opt.set_maxeval(Params::opt_nloptgrad::iterations());
 
                 if (bounded) {
                     opt.set_lower_bounds(std::vector<double>(f.param_size(), 0));

--- a/src/limbo/opt/nlopt_no_grad.hpp
+++ b/src/limbo/opt/nlopt_no_grad.hpp
@@ -10,7 +10,14 @@
 
 #include <nlopt.hpp>
 
+#include <limbo/tools/macros.hpp>
+
 namespace limbo {
+    namespace defaults {
+        struct opt_nloptnograd {
+            BO_PARAM(int, iterations, 500);
+        };
+    }
     namespace opt {
         template <typename Params, nlopt::algorithm Algorithm>
         struct NLOptNoGrad {
@@ -39,7 +46,7 @@ namespace limbo {
                 std::vector<double> x(f.init().size());
                 Eigen::VectorXd::Map(&x[0], f.init().size()) = f.init();
 
-                opt.set_maxeval(Params::nlopt::iters());
+                opt.set_maxeval(Params::opt_nloptnograd::iterations());
 
                 if (bounded) {
                     opt.set_lower_bounds(std::vector<double>(f.param_size(), 0));

--- a/src/limbo/opt/parallel_repeater.hpp
+++ b/src/limbo/opt/parallel_repeater.hpp
@@ -7,11 +7,12 @@
 
 #include <Eigen/Core>
 
+#include <limbo/tools/macros.hpp>
 #include <limbo/tools/parallel.hpp>
 
 namespace limbo {
     namespace defaults {
-        struct parallel_repeater {
+        struct opt_parallelrepeater {
             BO_PARAM(int, repeats, 10);
         };
     }
@@ -39,7 +40,7 @@ namespace limbo {
                 };
 
                 pair_t init = std::make_pair(f.init(), -std::numeric_limits<float>::max());
-                auto m = tools::par::max(init, Params::parallel_repeater::repeats(), body, comp);
+                auto m = tools::par::max(init, Params::opt_parallelrepeater::repeats(), body, comp);
 
                 return m.first;
             };

--- a/src/limbo/opt/rprop.hpp
+++ b/src/limbo/opt/rprop.hpp
@@ -7,12 +7,12 @@
 
 #include <Eigen/Core>
 
-#include <limbo/tools/parallel.hpp>
+#include <limbo/tools/macros.hpp>
 
 namespace limbo {
-    namespace defaults {
-        struct rprop {
-            BO_PARAM(int, iters, 300);
+   namespace defaults {
+        struct opt_rprop {
+            BO_PARAM(int, iterations, 300);
         };
     }
     namespace opt {
@@ -52,7 +52,7 @@ namespace limbo {
                 Eigen::VectorXd best_params = params;
                 double best = log(0);
 
-                for (int i = 0; i < Params::rprop::iters(); ++i) {
+                for (int i = 0; i < Params::opt_rprop::iterations(); ++i) {
                     auto perf = f.utility_and_grad(params);
                     double lik = std::get<0>(perf);
                     if (lik > best) {

--- a/src/limbo/stop/max_iterations.hpp
+++ b/src/limbo/stop/max_iterations.hpp
@@ -1,7 +1,14 @@
 #ifndef LIMBO_STOP_MAX_ITERATIONS_HPP
 #define LIMBO_STOP_MAX_ITERATIONS_HPP
 
+#include <limbo/tools/macros.hpp>
+
 namespace limbo {
+   namespace defaults {
+        struct stop_maxiterations {
+            BO_PARAM(int, iterations, 190);
+        };
+    }
     namespace stop {
         template <typename Params>
         struct MaxIterations {
@@ -10,7 +17,7 @@ namespace limbo {
             template <typename BO, typename AggregatorFunction>
             bool operator()(const BO& bo, const AggregatorFunction&)
             {
-                return bo.current_iteration() >= Params::maxiterations::n_iterations();
+                return bo.current_iteration() >= Params::stop_maxiterations::iterations();
             }
         };
     }

--- a/src/limbo/stop/max_predicted_value.hpp
+++ b/src/limbo/stop/max_predicted_value.hpp
@@ -10,13 +10,11 @@
 #include <limbo/tools/macros.hpp>
 
 namespace limbo {
-
     namespace defaults {
-        struct max_predicted_value {
+        struct stop_maxpredictedvalue {
             BO_PARAM(double, ratio, 0.9);
         };
     }
-
     namespace stop {
         template <typename Params, typename Optimizer = boost::parameter::void_>
         struct MaxPredictedValue {
@@ -34,11 +32,11 @@ namespace limbo {
                 Eigen::VectorXd starting_point = (Eigen::VectorXd::Random(bo.model().dim_in()).array() + 1) / 2;
                 double val = afun(bo.model().mu(optimizer(_make_model_mean_optimization(bo.model(), afun, starting_point), true)));
 
-                if (bo.observations().size() == 0 || afun(bo.best_observation(afun)) <= Params::max_predicted_value::ratio() * val)
+                if (bo.observations().size() == 0 || afun(bo.best_observation(afun)) <= Params::stop_maxpredictedvalue::ratio() * val)
                     return false;
                 else {
                     std::cout << "stop caused by Max predicted value reached. Thresold: "
-                              << Params::max_predicted_value::ratio() * val
+                              << Params::stop_maxpredictedvalue::ratio() * val
                               << " max observations: " << afun(bo.best_observation(afun)) << std::endl;
                     return true;
                 }

--- a/src/tests/all_combinations_template.cpp
+++ b/src/tests/all_combinations_template.cpp
@@ -8,59 +8,70 @@ using namespace limbo;
 
 struct Params {
 
-    struct kf_exp {
+    struct kernel_exp {
         BO_PARAM(double, sigma, 1);
     };
 
-    struct kf_maternthreehalfs {
-        BO_PARAM(double, sigma, 1);
-        BO_PARAM(double, l, 0.2);
-    };
-
-    struct kf_maternfivehalfs {
+    struct kernel_maternthreehalfs {
         BO_PARAM(double, sigma, 1);
         BO_PARAM(double, l, 0.2);
     };
 
-    struct meanconstant {
-        BO_PARAM_VECTOR(double, constant, 0, 0);
+    struct kernel_maternfivehalfs {
+        BO_PARAM(double, sigma, 1);
+        BO_PARAM(double, l, 0.2);
     };
 
-    struct ucb : public defaults::ucb {
+    struct mean_constant {
+        BO_PARAM(double, constant, 0);
     };
 
-    struct gp_ucb : public defaults::gp_ucb {
+    struct acqui_ucb : public defaults::acqui_ucb {
     };
 
-    struct grid_search {
-        BO_PARAM(int, nb_pts, 20);
+    struct acqui_gpucb : public defaults::acqui_gpucb {
     };
 
-    struct cmaes : public defaults::cmaes {
+    struct opt_gridsearch {
+        BO_PARAM(int, bins, 20);
     };
 
-    struct rprop : public defaults::rprop {
+    struct opt_cmaes : public defaults::opt_cmaes {
     };
 
-    struct parallel_repeater : public defaults::parallel_repeater {
+    struct opt_rprop : public defaults::opt_rprop {
     };
 
-    struct init {
-        BO_PARAM(int, nb_samples, 5);
-        BO_PARAM(int, nb_bins, 5);
+    struct opt_parallelrepeater : public defaults::opt_parallelrepeater {
     };
 
-    struct maxiterations {
-        BO_PARAM(int, n_iterations, 20);
+    struct init_gridsampling {
+            BO_PARAM(int, bins, 5);
     };
 
-    struct max_predicted_value {
+    struct init_randomsampling {
+        BO_PARAM(int, samples, 5);
+    };
+
+    struct init_randomsamplinggrid {
+        BO_PARAM(int, samples, 5);
+        BO_PARAM(int, bins, 5);
+    };
+
+    struct stop_maxiterations {
+        BO_PARAM(int, iterations, 20);
+    };
+
+    struct stop_maxpredictedvalue {
         BO_PARAM(double, ratio, 2);
     };
 
-    struct boptimizer {
-        BO_PARAM(double, noise, 0.001);
+    struct bayes_opt_bobase {
         BO_PARAM(bool, stats_enabled, true);
+    };
+
+    struct bayes_opt_boptimizer {
+        BO_PARAM(double, noise, 0.001);
     };
 };
 

--- a/src/tests/bo_functions.cpp
+++ b/src/tests/bo_functions.cpp
@@ -188,29 +188,32 @@ struct GoldenPrice {
 };
 
 struct Params {
-    struct boptimizer {
-        BO_PARAM(double, noise, 0.0);
+    struct bayes_opt_bobase {
         BO_PARAM(bool, stats_enabled, false);
     };
 
-    struct init {
-        BO_PARAM(int, nb_samples, 10);
+    struct bayes_opt_boptimizer {
+        BO_PARAM(double, noise, 0.0);
     };
 
-    struct maxiterations {
-        BO_PARAM(int, n_iterations, 40);
+    struct init_randomsampling {
+        BO_PARAM(int, samples, 10);
     };
 
-    struct gp_ucb : public defaults::gp_ucb {
+    struct stop_maxiterations {
+        BO_PARAM(int, iterations, 40);
     };
 
-    struct cmaes : public defaults::cmaes {
+    struct acqui_gpucb : public defaults::acqui_gpucb {
     };
 
-    struct rprop : public defaults::rprop {
+    struct opt_cmaes : public defaults::opt_cmaes {
     };
 
-    struct parallel_repeater : public defaults::parallel_repeater {
+    struct opt_rprop : public defaults::opt_rprop {
+    };
+
+    struct opt_parallelrepeater : public defaults::opt_parallelrepeater {
     };
 };
 

--- a/src/tests/test_boptimizer.cpp
+++ b/src/tests/test_boptimizer.cpp
@@ -9,32 +9,39 @@ using namespace limbo;
 
 struct Params {
 
-    struct rprop : public defaults::rprop {
+    struct opt_rprop : public defaults::opt_rprop {
     };
 
-    struct grid_search {
-        BO_PARAM(int, nb_pts, 10);
+    struct opt_gridsearch {
+        BO_PARAM(int, bins, 10);
     };
-    struct boptimizer {
+
+    struct bayes_opt_bobase {
+        BO_PARAM(bool, stats_enabled, false);
+    };
+
+    struct bayes_opt_boptimizer {
         BO_PARAM(double, noise, 0.0001);
-        BO_PARAM(bool, stats_enabled, true);
-    };
-    struct maxiterations {
-        BO_PARAM(int, n_iterations, 30);
     };
 
-    struct kf_maternfivehalfs {
+    struct stop_maxiterations {
+        BO_PARAM(int, iterations, 30);
+    };
+
+    struct kernel_maternfivehalfs {
         BO_PARAM(double, sigma, 1);
         BO_PARAM(double, l, 0.4);
     };
-    struct ucb {
+
+    struct acqui_ucb {
         BO_PARAM(double, alpha, 0.125);
     };
-    struct init {
-        BO_PARAM(int, nb_samples, 5);
+
+    struct init_randomsampling {
+        BO_PARAM(int, samples, 5);
     };
 
-    struct parallel_repeater : defaults::parallel_repeater {
+    struct opt_parallelrepeater : defaults::opt_parallelrepeater {
     };
 };
 

--- a/src/tests/test_boptimizer.cpp
+++ b/src/tests/test_boptimizer.cpp
@@ -24,11 +24,11 @@ struct Params {
     };
 
     struct kf_maternfivehalfs {
-        BO_PARAM(float, sigma, 1);
-        BO_PARAM(float, l, 0.4);
+        BO_PARAM(double, sigma, 1);
+        BO_PARAM(double, l, 0.4);
     };
     struct ucb {
-        BO_PARAM(float, alpha, 0.125);
+        BO_PARAM(double, alpha, 0.125);
     };
     struct init {
         BO_PARAM(int, nb_samples, 5);

--- a/src/tests/test_gp.cpp
+++ b/src/tests/test_gp.cpp
@@ -20,19 +20,18 @@ Eigen::VectorXd make_v1(double x)
 }
 
 struct Params {
-    struct kf_maternfivehalfs {
+    struct kernel_maternfivehalfs {
         BO_PARAM(double, sigma, 1);
         BO_PARAM(double, l, 0.25);
     };
 
-    struct meanconstant {
-        static Eigen::VectorXd constant() { return make_v1(0.0); };
+    struct mean_constant : public defaults::mean_constant {
     };
 
-    struct rprop : public defaults::rprop {
+    struct opt_rprop : public defaults::opt_rprop {
     };
 
-    struct parallel_repeater : public defaults::parallel_repeater {
+    struct opt_parallelrepeater : public defaults::opt_parallelrepeater {
     };
 };
 

--- a/src/tests/test_init_functions.cpp
+++ b/src/tests/test_init_functions.cpp
@@ -18,37 +18,36 @@ Eigen::VectorXd make_v1(double x)
 }
 
 struct Params {
-    struct boptimizer {
-        BO_PARAM(double, noise, 0.01);
+    struct bayes_opt_bobase {
         BO_PARAM(bool, stats_enabled, false);
     };
 
-    struct maxiterations {
-        BO_PARAM(int, n_iterations, 0);
+    struct bayes_opt_boptimizer {
+        BO_PARAM(double, noise, 0.01);
     };
 
-    struct kf_maternfivehalfs {
+    struct stop_maxiterations {
+        BO_PARAM(int, iterations, 0);
+    };
+
+    struct kernel_maternfivehalfs {
         BO_PARAM(double, sigma, 1);
         BO_PARAM(double, l, 0.25);
     };
 
-    struct ucb : public defaults::ucb {
+    struct acqui_ucb : public defaults::acqui_ucb {
     };
 
-    struct gp_ucb : public defaults::gp_ucb {
+    struct acqui_gpucb : public defaults::acqui_gpucb {
     };
 
-    struct meanconstant {
-        static Eigen::VectorXd constant() { return make_v1(0.0); };
+    struct opt_cmaes : public defaults::opt_cmaes {
     };
 
-    struct cmaes : public defaults::cmaes {
+    struct opt_rprop : public defaults::opt_rprop {
     };
 
-    struct rprop : public defaults::rprop {
-    };
-
-    struct parallel_repeater : public defaults::parallel_repeater {
+    struct opt_parallelrepeater : public defaults::opt_parallelrepeater {
     };
 };
 
@@ -81,8 +80,8 @@ BOOST_AUTO_TEST_CASE(random_sampling)
 {
     std::cout << "RandomSampling" << std::endl;
     struct MyParams : public Params {
-        struct init {
-            BO_PARAM(int, nb_samples, 10);
+        struct init_randomsampling {
+            BO_PARAM(int, samples, 10);
         };
     };
 
@@ -107,9 +106,9 @@ BOOST_AUTO_TEST_CASE(random_sampling_grid)
 {
     std::cout << "RandomSamplingGrid" << std::endl;
     struct MyParams : public Params {
-        struct init {
-            BO_PARAM(int, nb_samples, 10);
-            BO_PARAM(int, nb_bins, 4);
+        struct init_randomsamplinggrid {
+            BO_PARAM(int, samples, 10);
+            BO_PARAM(int, bins, 4);
         };
     };
 
@@ -135,8 +134,8 @@ BOOST_AUTO_TEST_CASE(grid_sampling)
 {
     std::cout << "GridSampling" << std::endl;
     struct MyParams : public Params {
-        struct init {
-            BO_PARAM(int, nb_bins, 4);
+        struct init_gridsampling {
+            BO_PARAM(int, bins, 4);
         };
     };
 

--- a/src/tests/test_nlopt.cpp
+++ b/src/tests/test_nlopt.cpp
@@ -8,8 +8,12 @@
 #include <limbo/opt/nlopt_no_grad.hpp>
 
 struct Params {
-    struct nlopt {
-        BO_PARAM(int, iters, 80);
+    struct opt_nloptgrad {
+        BO_PARAM(int, iterations, 80);
+    };
+
+    struct opt_nloptnograd {
+        BO_PARAM(int, iterations, 80);
     };
 };
 

--- a/src/tests/test_optimizers.cpp
+++ b/src/tests/test_optimizers.cpp
@@ -18,11 +18,11 @@ Eigen::VectorXd make_v1(double x)
 }
 
 struct Params {
-    struct grid_search {
-        BO_PARAM(int, nb_pts, 20);
+    struct opt_gridsearch {
+        BO_PARAM(int, bins, 20);
     };
 
-    struct cmaes : public defaults::cmaes {
+    struct opt_cmaes : public defaults::opt_cmaes {
     };
 };
 
@@ -128,7 +128,7 @@ BOOST_AUTO_TEST_CASE(test_grid_search_mono_dim)
 
     BOOST_CHECK_EQUAL(best_point.size(), 1);
     BOOST_CHECK_CLOSE(best_point(0), 1, 0.0001);
-    BOOST_CHECK_EQUAL(monodim_calls, Params::grid_search::nb_pts() + 1);
+    BOOST_CHECK_EQUAL(monodim_calls, Params::opt_gridsearch::bins() + 1);
 }
 
 BOOST_AUTO_TEST_CASE(test_grid_search_bi_dim)
@@ -146,7 +146,7 @@ BOOST_AUTO_TEST_CASE(test_grid_search_bi_dim)
     BOOST_CHECK_CLOSE(best_point(0), 1, 0.0001);
     BOOST_CHECK_SMALL(best_point(1), 0.000001);
     // TO-DO: Maybe alter a little grid search so not to call more times the utility function
-    BOOST_CHECK_EQUAL(bidim_calls, (Params::grid_search::nb_pts() + 1) * (Params::grid_search::nb_pts() + 1) + 21);
+    BOOST_CHECK_EQUAL(bidim_calls, (Params::opt_gridsearch::bins() + 1) * (Params::opt_gridsearch::bins() + 1) + 21);
 }
 
 BOOST_AUTO_TEST_CASE(test_cmaes_mono_dim)


### PR DESCRIPTION
I made the following changes to the parameters structs:
- Converted to double all variables that were float
- Renamed parameters to be consistent: removed innecesary "nb" and "n" (e.g. nb_bins, nrestarts); give the same name to parameters on different classes that mean the same (e.g. iterations, samples, bins)
- Applied the following convention to the struct names: namespace (separated with underscores if there is more than one) + "_" + class name (all lowercase, without separating the words)