### PR TITLE
removed boost::shared_ptr and replaced them with std::shared_ptr

### DIFF
--- a/src/cmaes/cmaes.c
+++ b/src/cmaes/cmaes.c
@@ -2287,7 +2287,7 @@ long random_init(random_t* t, long unsigned inseed)
     if (inseed < 1) {
         while ((long)(cloc - clock()) == 0)
             ; /* TODO: remove this for time critical applications? */
-        inseed = (long unsigned)abs((long)(100 * time(NULL) + clock()));
+        inseed = (long unsigned)labs((long)(100 * time(NULL) + clock()));
     }
     return random_Start(t, inseed);
 }
@@ -2670,7 +2670,7 @@ void readpara_SupplementDefaults(readpara_t* t)
     if (t->seed < 1) {
         while ((int)(cloc - clock()) == 0)
             ; /* TODO: remove this for time critical applications!? */
-        t->seed = (unsigned int)abs((long)(100 * time(NULL) + clock()));
+        t->seed = (unsigned int)labs((long)(100 * time(NULL) + clock()));
     }
 
     if (t->stStopFitness.flg == -1)

--- a/src/ehvi/ehvi_calculations.cc
+++ b/src/ehvi/ehvi_calculations.cc
@@ -88,7 +88,7 @@ double ehvi3d_2term(deque<individual*> P, double r[], double mu[],
     double Sminus; // Correction term for the integral.
     deque<individual*> Py, Pz; // P sorted by y/z coordinate
     sort(P.begin(), P.end(), ycomparator);
-    for (int i = 0; i < P.size(); i++) {
+    for (size_t i = 0; i < P.size(); i++) {
         Py.push_back(P[i]);
     }
     sort(P.begin(), P.end(), zcomparator);
@@ -145,7 +145,7 @@ double ehvi3d_5term(deque<individual*> P, double r[], double mu[],
     double Sminus; // Correction term for the integral.
     deque<individual*> Py, Pz; // P sorted by y/z coordinate
     sort(P.begin(), P.end(), ycomparator);
-    for (int i = 0; i < P.size(); i++) {
+    for (size_t i = 0; i < P.size(); i++) {
         Py.push_back(P[i]);
     }
     sort(P.begin(), P.end(), zcomparator);
@@ -231,7 +231,7 @@ double ehvi3d_8term(deque<individual*> P, double r[], double mu[],
         tempimp; // Correction term, rectangular volume, temp. improvement
     deque<individual*> Py, Pz; // P sorted by y/z coordinate
     sort(P.begin(), P.end(), ycomparator);
-    for (int i = 0; i < P.size(); i++) {
+    for (size_t i = 0; i < P.size(); i++) {
         Py.push_back(P[i]);
     }
     sort(P.begin(), P.end(), zcomparator);

--- a/src/ehvi/ehvi_multi.cc
+++ b/src/ehvi/ehvi_multi.cc
@@ -20,15 +20,15 @@ vector<double> ehvi3d_5term(deque<individual*> P, double r[],
     double Sminus; // Correction term for the integral.
     deque<individual*> Py, Pz; // P sorted by y/z coordinate
     sort(P.begin(), P.end(), ycomparator);
-    for (int i = 0; i < P.size(); i++) {
+    for (size_t i = 0; i < P.size(); i++) {
         Py.push_back(P[i]);
     }
     sort(P.begin(), P.end(), zcomparator);
-    for (unsigned int i = 0; i < P.size(); i++) {
+    for (size_t i = 0; i < P.size(); i++) {
         Pz.push_back(P[i]);
     }
     sort(P.begin(), P.end(), xcomparator);
-    for (int i = 0; i < pdf.size(); i++) {
+    for (size_t i = 0; i < pdf.size(); i++) {
         answer.push_back(0);
     }
     for (int z = 0; z <= n; z++) {
@@ -72,7 +72,7 @@ vector<double> ehvi3d_5term(deque<individual*> P, double r[],
                 double yslice = calculateslice(Py, v, cl, 1);
                 double zslice = calculateslice(Pz, v, cl, 2);
                 // And then we integrate.
-                for (int i = 0; i < pdf.size(); i++) {
+                for (size_t i = 0; i < pdf.size(); i++) {
                     double psi1 = exipsi(v[0], cl[0], pdf[i]->mu[0], pdf[i]->s[0]) - exipsi(v[0], cu[0], pdf[i]->mu[0], pdf[i]->s[0]);
                     double psi2 = exipsi(v[1], cl[1], pdf[i]->mu[1], pdf[i]->s[1]) - exipsi(v[1], cu[1], pdf[i]->mu[1], pdf[i]->s[1]);
                     double psi3 = exipsi(v[2], cl[2], pdf[i]->mu[2], pdf[i]->s[2]) - exipsi(v[2], cu[2], pdf[i]->mu[2], pdf[i]->s[2]);
@@ -116,7 +116,7 @@ vector<double> ehvi3d_sliceupdate(deque<individual*> P, double r[DIMENSIONS],
         // location in
         // the other sorting orders to be ascertained in O(1).
         sort(P.begin(), P.end(), xcomparator);
-        for (unsigned int i = 0; i < n; i++) {
+        for (int i = 0; i < n; i++) {
             newind = new specialind;
             newind->point = P[i];
             newind->xorder = i;
@@ -125,11 +125,11 @@ vector<double> ehvi3d_sliceupdate(deque<individual*> P, double r[DIMENSIONS],
             Pz.push_back(newind);
         }
         sort(Py.begin(), Py.end(), specialycomparator);
-        for (unsigned int i = 0; i < n; i++) {
+        for (int i = 0; i < n; i++) {
             Py[i]->yorder = i;
         }
         sort(Pz.begin(), Pz.end(), specialzcomparator);
-        for (unsigned int i = 0; i < n; i++) {
+        for (int i = 0; i < n; i++) {
             Pz[i]->zorder = i;
         }
         // Then also reserve memory for the structure array.
@@ -244,7 +244,7 @@ vector<double> ehvi3d_sliceupdate(deque<individual*> P, double r[DIMENSIONS],
                     v[2] = (Pstruct[x + y * n].highestdominator == -1
                             ? 0
                             : (Pz[Pstruct[x + y * n].highestdominator]->point->f[2] - r[2]));
-                for (int i = 0; i < pdf.size(); i++) {
+                for (size_t i = 0; i < pdf.size(); i++) {
                     double psi1 = exipsi(r[0], cl[0], pdf[i]->mu[0], pdf[i]->s[0]) - exipsi(r[0], cu[0], pdf[i]->mu[0], pdf[i]->s[0]);
                     double psi2 = exipsi(r[1], cl[1], pdf[i]->mu[1], pdf[i]->s[1]) - exipsi(r[1], cu[1], pdf[i]->mu[1], pdf[i]->s[1]);
                     double psi3 = exipsi(r[2], cl[2], pdf[i]->mu[2], pdf[i]->s[2]) - exipsi(r[2], cu[2], pdf[i]->mu[2], pdf[i]->s[2]);

--- a/src/ehvi/ehvi_sliceupdate.cc
+++ b/src/ehvi/ehvi_sliceupdate.cc
@@ -27,7 +27,7 @@ double ehvi3d_sliceupdate(deque<individual*> P, double r[], double mu[],
         // location in
         // the other sorting orders to be ascertained in O(1).
         sort(P.begin(), P.end(), xcomparator);
-        for (unsigned int i = 0; i < n; i++) {
+        for (int i = 0; i < n; i++) {
             newind = new specialind;
             newind->point = P[i];
             newind->xorder = i;
@@ -36,11 +36,11 @@ double ehvi3d_sliceupdate(deque<individual*> P, double r[], double mu[],
             Pz.push_back(newind);
         }
         sort(Py.begin(), Py.end(), specialycomparator);
-        for (unsigned int i = 0; i < n; i++) {
+        for (int i = 0; i < n; i++) {
             Py[i]->yorder = i;
         }
         sort(Pz.begin(), Pz.end(), specialzcomparator);
-        for (unsigned int i = 0; i < n; i++) {
+        for (int i = 0; i < n; i++) {
             Pz[i]->zorder = i;
         }
         // Then also reserve memory for the structure array.

--- a/src/limbo/bayes_opt/boptimizer.hpp
+++ b/src/limbo/bayes_opt/boptimizer.hpp
@@ -6,7 +6,6 @@
 #include <iterator>
 
 #include <boost/parameter/aux_/void.hpp>
-#include <boost/range/adaptor/transformed.hpp>
 
 #include <Eigen/Core>
 
@@ -65,8 +64,8 @@ namespace limbo {
                 this->_init(sfun, afun, reset);
 
                 if (!this->_observations.empty())
-                        _model.compute(this->_samples, this->_observations, Params::bayes_opt_boptimizer::noise(), this->_bl_samples);
-                
+                    _model.compute(this->_samples, this->_observations, Params::bayes_opt_boptimizer::noise(), this->_bl_samples);
+
                 acqui_optimizer_t acqui_optimizer;
 
                 while (this->_samples.size() == 0 || !this->_stop(*this, afun)) {
@@ -90,7 +89,8 @@ namespace limbo {
                               << (blacklisted ? this->_bl_samples.back()
                                               : this->_samples.back()).transpose();
                     if (blacklisted)
-                        std::cout << " value: " << "No data, blacklisted";
+                        std::cout << " value: "
+                                  << "No data, blacklisted";
                     else
                         std::cout << " value: " << afun(this->_observations.back());
 
@@ -114,7 +114,8 @@ namespace limbo {
             template <typename AggregatorFunction = FirstElem>
             const Eigen::VectorXd& best_observation(const AggregatorFunction& afun = AggregatorFunction()) const
             {
-                auto rewards = boost::adaptors::transform(this->_observations, afun);
+                auto rewards = std::vector<double>(this->_observations.size());
+                std::transform(this->_observations.begin(), this->_observations.end(), rewards.begin(), afun);
                 auto max_e = std::max_element(rewards.begin(), rewards.end());
                 return this->_observations[std::distance(rewards.begin(), max_e)];
             }
@@ -122,7 +123,8 @@ namespace limbo {
             template <typename AggregatorFunction = FirstElem>
             const Eigen::VectorXd& best_sample(const AggregatorFunction& afun = AggregatorFunction()) const
             {
-                auto rewards = boost::adaptors::transform(this->_observations, afun);
+                auto rewards = std::vector<double>(this->_observations.size());
+                std::transform(this->_observations.begin(), this->_observations.end(), rewards.begin(), afun);
                 auto max_e = std::max_element(rewards.begin(), rewards.end());
                 return this->_samples[std::distance(rewards.begin(), max_e)];
             }

--- a/src/limbo/init/random_sampling.hpp
+++ b/src/limbo/init/random_sampling.hpp
@@ -4,7 +4,7 @@
 #include <Eigen/Core>
 
 #include <limbo/tools/macros.hpp>
-#include <limbo/tools/rand.hpp>
+#include <limbo/tools/math.hpp>
 
 namespace limbo {
     namespace defaults {
@@ -21,7 +21,7 @@ namespace limbo {
                 for (int i = 0; i < Params::init_randomsampling::samples(); i++) {
                     Eigen::VectorXd new_sample(StateFunction::dim_in);
                     for (int i = 0; i < StateFunction::dim_in; i++)
-                        new_sample[i] = tools::rand<double>(0, 1);                 
+                        new_sample[i] = tools::rand<double>(0, 1);
                     opt.add_new_sample(new_sample, seval(new_sample));
                 }
             }

--- a/src/limbo/init/random_sampling.hpp
+++ b/src/limbo/init/random_sampling.hpp
@@ -20,8 +20,8 @@ namespace limbo {
             {
                 for (int i = 0; i < Params::init_randomsampling::samples(); i++) {
                     Eigen::VectorXd new_sample(StateFunction::dim_in);
-                    for (int i = 0; i < StateFunction::dim_in; i++)
-                        new_sample[i] = tools::rand<double>(0, 1);
+                    for (size_t j = 0; j < StateFunction::dim_in; j++)
+                        new_sample[j] = tools::rand<double>(0, 1);
                     opt.add_new_sample(new_sample, seval(new_sample));
                 }
             }

--- a/src/limbo/model/gp.hpp
+++ b/src/limbo/model/gp.hpp
@@ -180,8 +180,8 @@ namespace limbo {
             {
                 // O(n^2) [should be negligible]
                 _kernel.resize(_samples.size(), _samples.size());
-                for (int i = 0; i < _samples.size(); i++)
-                    for (int j = 0; j < _samples.size(); ++j)
+                for (size_t i = 0; i < _samples.size(); i++)
+                    for (size_t j = 0; j < _samples.size(); ++j)
                         _kernel(i, j) = _kernel_function(_samples[i], _samples[j]) + ((i == j) ? _noise : 0); // noise only on the diagonal
 
                 // O(n^3)

--- a/src/limbo/opt/cmaes.hpp
+++ b/src/limbo/opt/cmaes.hpp
@@ -43,7 +43,7 @@ namespace limbo {
                 int irun, lambda = 0, countevals = 0;
                 char const* stop;
                 boundary_transformation_t boundaries;
-                double lowerBounds[] = {0.0}; 
+                double lowerBounds[] = {0.0};
                 double upperBounds[] = {1.006309}; // Allows solution to be pretty close to 1
                 int nb_bounds = 1; /* numbers used from lower and upperBounds */
 
@@ -51,7 +51,7 @@ namespace limbo {
 
                 double* x_in_bounds = cmaes_NewDouble(dim);
                 double init_point[dim];
-                for (int i = 0; i < dim; ++i)
+                for (size_t i = 0; i < dim; ++i)
                     init_point[i] = f.init()(i);
 
                 for (irun = 0; irun < nrestarts + 1; ++irun) {
@@ -74,7 +74,7 @@ namespace limbo {
                         tools::par::loop(0, pop_size, [&](int i) {
                             // clang-format off
                             boundary_transformation(&boundaries, pop[i], all_x_in_bounds[i], dim);
-                            for (int j = 0; j < dim; ++j)
+                            for (size_t j = 0; j < dim; ++j)
                               pop_eigen[i](j) = all_x_in_bounds[i][j];
                             fitvals[i] = -f.utility(pop_eigen[i]);
                             // clang-format on

--- a/src/limbo/opt/grid_search.hpp
+++ b/src/limbo/opt/grid_search.hpp
@@ -8,11 +8,11 @@
 #include <limbo/tools/macros.hpp>
 
 namespace limbo {
-   namespace defaults {
+    namespace defaults {
         struct opt_gridsearch {
             BO_PARAM(int, bins, 5);
         };
-    }    
+    }
     namespace opt {
         template <typename Params>
         struct GridSearch {
@@ -27,7 +27,7 @@ namespace limbo {
 
         protected:
             template <typename F>
-            Eigen::VectorXd _inner_search(const F& f, int depth, const Eigen::VectorXd& current) const
+            Eigen::VectorXd _inner_search(const F& f, size_t depth, const Eigen::VectorXd& current) const
             {
                 double step_size = 1.0 / (double)Params::opt_gridsearch::bins();
                 double upper_lim = 1.0 + step_size;

--- a/src/limbo/opt/parallel_repeater.hpp
+++ b/src/limbo/opt/parallel_repeater.hpp
@@ -3,8 +3,6 @@
 
 #include <algorithm>
 
-#include <boost/math/special_functions/sign.hpp>
-
 #include <Eigen/Core>
 
 #include <limbo/tools/macros.hpp>

--- a/src/limbo/opt/rprop.hpp
+++ b/src/limbo/opt/rprop.hpp
@@ -8,9 +8,10 @@
 #include <Eigen/Core>
 
 #include <limbo/tools/macros.hpp>
+#include <limbo/tools/math.hpp>
 
 namespace limbo {
-   namespace defaults {
+    namespace defaults {
         struct opt_rprop {
             BO_PARAM(int, iterations, 300);
         };
@@ -70,7 +71,7 @@ namespace limbo {
                             delta(j) = std::max(delta(j) * etaminus, deltamin);
                             grad(j) = 0;
                         }
-                        params(j) += -boost::math::sign(grad(j)) * delta(j);
+                        params(j) += -tools::signum(grad(j)) * delta(j);
 
                         if (bounded && params(j) < 0)
                             params(j) = 0;

--- a/src/limbo/stat/stat_base.hpp
+++ b/src/limbo/stat/stat_base.hpp
@@ -4,7 +4,7 @@
 #include <fstream>
 #include <string>
 
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 namespace limbo {
     namespace stat {
@@ -19,14 +19,14 @@ namespace limbo {
             }
 
         protected:
-            boost::shared_ptr<std::ofstream> _log_file;
+            std::shared_ptr<std::ofstream> _log_file;
 
             template <typename BO>
             void _create_log_file(const BO& bo, const std::string& name)
             {
                 if (!_log_file && bo.stats_enabled()) {
                     std::string log = bo.res_dir() + "/" + name;
-                    _log_file = boost::shared_ptr<std::ofstream>(new std::ofstream(log.c_str()));
+                    _log_file = std::make_shared<std::ofstream>(log.c_str());
                 }
             }
         };

--- a/src/limbo/tools.hpp
+++ b/src/limbo/tools.hpp
@@ -3,7 +3,7 @@
 
 #include <limbo/tools/macros.hpp>
 #include <limbo/tools/parallel.hpp>
-#include <limbo/tools/rand.hpp>
+#include <limbo/tools/math.hpp>
 #include <limbo/tools/sys.hpp>
 
 #endif

--- a/src/limbo/tools/math.hpp
+++ b/src/limbo/tools/math.hpp
@@ -34,8 +34,8 @@
 //| The fact that you are presently reading this means that you have
 //| had knowledge of the CeCILL license and that you accept its terms.
 
-#ifndef LIMBO_TOOLS_RAND_HPP
-#define LIMBO_TOOLS_RAND_HPP
+#ifndef LIMBO_TOOLS_MATH_HPP
+#define LIMBO_TOOLS_MATH_HPP
 
 #include <cstdlib>
 #include <cmath>
@@ -112,6 +112,25 @@ namespace limbo {
             for (size_t i = 0; i < k; ++i)
                 ++it;
             return it;
+        }
+
+        // get sign of number
+        template <typename T>
+        inline constexpr int signum(T x, std::false_type is_signed)
+        {
+            return T(0) < x;
+        }
+
+        template <typename T>
+        inline constexpr int signum(T x, std::true_type is_signed)
+        {
+            return (T(0) < x) - (x < T(0));
+        }
+
+        template <typename T>
+        inline constexpr int signum(T x)
+        {
+            return signum(x, std::is_signed<T>());
         }
     }
 }

--- a/src/limbo/tools/math.hpp
+++ b/src/limbo/tools/math.hpp
@@ -43,8 +43,7 @@
 #include <list>
 #include <stdlib.h>
 #include <random>
-
-#include <boost/swap.hpp>
+#include <utility>
 
 // someday we will have a real thread-safe random number generator...
 namespace limbo {
@@ -87,7 +86,7 @@ namespace limbo {
             for (size_t i = 0; i < a1.size(); ++i) {
                 size_t k = rand(i, a1.size());
                 assert(k < a1.size());
-                boost::swap(a1[i], a1[k]);
+                std::swap(a1[i], a1[k]);
             }
         }
 

--- a/src/limbo/tools/sys.hpp
+++ b/src/limbo/tools/sys.hpp
@@ -39,8 +39,6 @@
 #include <unistd.h>
 #include <string>
 
-#include <boost/lexical_cast.hpp>
-
 namespace limbo {
     namespace tools {
         inline std::string date()
@@ -49,7 +47,7 @@ namespace limbo {
             time_t date_time;
             time(&date_time);
             strftime(date, 30, "%Y-%m-%d_%H_%M_%S", localtime(&date_time));
-            return date;
+            return std::string(date);
         }
 
         inline std::string hostname()
@@ -63,7 +61,7 @@ namespace limbo {
 
         inline std::string getpid()
         {
-            return boost::lexical_cast<std::string>(::getpid());
+            return std::to_string(::getpid());
         }
     }
 }

--- a/src/tests/test_gp.cpp
+++ b/src/tests/test_gp.cpp
@@ -53,15 +53,15 @@ BOOST_AUTO_TEST_CASE(test_gp)
     Eigen::VectorXd mu;
     double sigma;
     std::tie(mu, sigma) = gp.query(make_v1(1));
-    BOOST_CHECK(abs((mu(0) - 5)) < 1);
+    BOOST_CHECK(std::abs((mu(0) - 5)) < 1);
     BOOST_CHECK(sigma < 1e-5);
 
     std::tie(mu, sigma) = gp.query(make_v1(2));
-    BOOST_CHECK(abs((mu(0) - 10)) < 1);
+    BOOST_CHECK(std::abs((mu(0) - 10)) < 1);
     BOOST_CHECK(sigma < 1e-5);
 
     std::tie(mu, sigma) = gp.query(make_v1(3));
-    BOOST_CHECK(abs((mu(0) - 5)) < 1);
+    BOOST_CHECK(std::abs((mu(0) - 5)) < 1);
     BOOST_CHECK(sigma < 1e-5);
 
     for (double x = 0; x < 4; x += 0.05) {
@@ -123,14 +123,14 @@ BOOST_AUTO_TEST_CASE(test_gp_auto)
     Eigen::VectorXd mu;
     double sigma;
     std::tie(mu, sigma) = gp.query(make_v1(1));
-    BOOST_CHECK(abs((mu(0) - 5)) < 1);
+    BOOST_CHECK(std::abs((mu(0) - 5)) < 1);
     BOOST_CHECK(sigma < 1e-5);
 
     std::tie(mu, sigma) = gp.query(make_v1(2));
-    BOOST_CHECK(abs((mu(0) - 10)) < 1);
+    BOOST_CHECK(std::abs((mu(0) - 10)) < 1);
     BOOST_CHECK(sigma < 1e-5);
 
     std::tie(mu, sigma) = gp.query(make_v1(3));
-    BOOST_CHECK(abs((mu(0) - 5)) < 1);
+    BOOST_CHECK(std::abs((mu(0) - 5)) < 1);
     BOOST_CHECK(sigma < 1e-5);
 }


### PR DESCRIPTION
There is no reason to use boost's shared_ptr since they have been included in the standard.