### PR TITLE
Move standard output to stats

### DIFF
--- a/src/limbo/bayes_opt/bo_base.hpp
+++ b/src/limbo/bayes_opt/bo_base.hpp
@@ -20,6 +20,7 @@
 #include <limbo/stop/max_iterations.hpp>
 #include <limbo/stat/samples.hpp>
 #include <limbo/stat/aggregated_observations.hpp>
+#include <limbo/stat/console_summary.hpp>
 #include <limbo/tools/sys.hpp>
 #include <limbo/kernel/squared_exp_ard.hpp>
 #include <limbo/acqui/gp_ucb.hpp>
@@ -32,7 +33,7 @@
 namespace limbo {
     namespace defaults {
         struct bayes_opt_bobase {
-            BO_PARAM(bool, stats_enabled, true);            
+            BO_PARAM(bool, stats_enabled, true);
         };
     }
     template <typename BO, typename AggregatorFunction>
@@ -108,7 +109,7 @@ namespace limbo {
                 // WARNING: you have to specify the acquisition  function
                 // if you use a custom model
                 typedef acqui::GP_UCB<Params, model_t> acqui_t; // 4
-                typedef boost::fusion::vector<stat::Samples<Params>, stat::AggregatedObservations<Params>> stat_t; // 5
+                typedef boost::fusion::vector<stat::Samples<Params>, stat::AggregatedObservations<Params>, stat::ConsoleSummary<Params>> stat_t; // 5
                 typedef boost::fusion::vector<stop::MaxIterations<Params>> stop_t; // 6
             };
 
@@ -165,7 +166,7 @@ namespace limbo {
                     this->_total_iterations = 0;
                     this->_samples.clear();
                     this->_observations.clear();
-                    this->_bl_samples.clear();                    
+                    this->_bl_samples.clear();
                 }
 
                 if (this->_total_iterations == 0)

--- a/src/limbo/bayes_opt/boptimizer.hpp
+++ b/src/limbo/bayes_opt/boptimizer.hpp
@@ -65,8 +65,8 @@ namespace limbo {
                 this->_init(sfun, afun, reset);
 
                 if (!this->_observations.empty())
-                        _model.compute(this->_samples, this->_observations, Params::bayes_opt_boptimizer::noise(), this->_bl_samples);
-                
+                    _model.compute(this->_samples, this->_observations, Params::bayes_opt_boptimizer::noise(), this->_bl_samples);
+
                 acqui_optimizer_t acqui_optimizer;
 
                 while (this->_samples.size() == 0 || !this->_stop(*this, afun)) {
@@ -85,23 +85,6 @@ namespace limbo {
                     }
 
                     this->_update_stats(*this, afun, blacklisted);
-
-                    std::cout << this->_current_iteration << " new point: "
-                              << (blacklisted ? this->_bl_samples.back()
-                                              : this->_samples.back()).transpose();
-                    if (blacklisted)
-                        std::cout << " value: " << "No data, blacklisted";
-                    else
-                        std::cout << " value: " << afun(this->_observations.back());
-
-                    // std::cout << " mu: "<< _model.mu(blacklisted ? this->_bl_samples.back()
-                    // : this->_samples.back()).transpose()
-                    //<< " mean: " << _model.mean_function()(new_sample, _model).transpose()
-                    //<< " sigma: "<< _model.sigma(blacklisted ? this->_bl_samples.back() :
-                    //this->_samples.back())
-                    //<< " acqui: "<< acqui(blacklisted ? this->_bl_samples.back() :
-                    //this->_samples.back(), afun)
-                    std::cout << " best:" << afun(this->best_observation(afun)) << std::endl;
 
                     if (!this->_observations.empty())
                         _model.compute(this->_samples, this->_observations, Params::bayes_opt_boptimizer::noise(), this->_bl_samples);

--- a/src/limbo/stat.hpp
+++ b/src/limbo/stat.hpp
@@ -5,6 +5,7 @@
 #include <limbo/stat/best_observations.hpp>
 #include <limbo/stat/best_samples.hpp>
 #include <limbo/stat/bl_samples.hpp>
+#include <limbo/stat/console_summary.hpp>
 #include <limbo/stat/aggregated_observations.hpp>
 #include <limbo/stat/observations.hpp>
 #include <limbo/stat/gp_acquisitions.hpp>

--- a/src/limbo/stat/console_summary.hpp
+++ b/src/limbo/stat/console_summary.hpp
@@ -1,0 +1,31 @@
+#ifndef LIMBO_STAT_CONSOLE_SUMMARY_HPP
+#define LIMBO_STAT_CONSOLE_SUMMARY_HPP
+
+#include <limbo/stat/stat_base.hpp>
+
+namespace limbo {
+    namespace stat {
+        template <typename Params>
+        struct ConsoleSummary : public StatBase<Params> {
+            template <typename BO, typename AggregatorFunction>
+            void operator()(const BO& bo, const AggregatorFunction& afun, bool blacklisted)
+            {
+                if (!bo.stats_enabled() || bo.observations().empty())
+                    return;
+
+                std::cout << bo.total_iterations() << " new point: "
+                          << (blacklisted ? bo.bl_samples().back()
+                                          : bo.samples().back()).transpose();
+                if (blacklisted)
+                    std::cout << " value: "
+                              << "No data, blacklisted";
+                else
+                    std::cout << " value: " << afun(bo.observations().back());
+
+                std::cout << " best:" << afun(bo.best_observation(afun)) << std::endl;
+            }
+        };
+    }
+}
+
+#endif


### PR DESCRIPTION
As discussed in #53, it's better to have the standard output in stats. I created a stat `ConsoleSummary` that directly outputs in the standard output (std::cout) only if the user wants it (e.g. debugging purposes). It is enabled in the defaults: I am assuming that new users (that will use the defaults) should get some standard output.