### PR TITLE
Conditional includes and minor bug fix

### DIFF
--- a/src/limbo/bayes_opt.hpp
+++ b/src/limbo/bayes_opt.hpp
@@ -2,8 +2,10 @@
 #define LIMBO_BAYES_OPT_HPP
 
 #include <limbo/bayes_opt/boptimizer.hpp>
+#ifdef USE_SFERES
 #include <limbo/bayes_opt/ehvi.hpp>
 #include <limbo/bayes_opt/nsbo.hpp>
 #include <limbo/bayes_opt/parego.hpp>
+#endif
 
 #endif

--- a/src/limbo/bayes_opt/bo_base.hpp
+++ b/src/limbo/bayes_opt/bo_base.hpp
@@ -25,9 +25,13 @@
 #include <limbo/kernel/squared_exp_ard.hpp>
 #include <limbo/acqui/gp_ucb.hpp>
 #include <limbo/mean/data.hpp>
-#include <limbo/opt/grid_search.hpp>
+#ifdef USE_LIBCMAES
 #include <limbo/opt/cmaes.hpp>
+#elif defined USE_NLOPT
 #include <limbo/opt/nlopt_no_grad.hpp>
+#else
+#include <limbo/opt/grid_search.hpp>
+#endif
 #include <limbo/model/gp.hpp>
 #include <limbo/model/gp/kernel_lf_opt.hpp>
 #include <limbo/init/random_sampling.hpp>
@@ -107,7 +111,7 @@ namespace limbo {
 #ifdef USE_LIBCMAES
                 typedef opt::Cmaes<Params> acquiopt_t; // 2
 #elif defined(USE_NLOPT)
-  	        typedef opt::NLOptNoGrad<Params, NLOPT_GLOBAL_DIRECT_L_RAND> aquiopt_t;
+  	        typedef opt::NLOptNoGrad<Params, nlopt::GN_DIRECT_L_RAND> acquiopt_t;
 #else
 #warning NO NLOpt, and NO Libcmaes: the acquisition function will be optimized by a grid search algorithm (which is usually bad). Please install at least NLOpt or libcmaes to use limbo!.
 	      typedef opt::GridSearch<Params> acquiopt_t;

--- a/src/limbo/opt.hpp
+++ b/src/limbo/opt.hpp
@@ -1,7 +1,9 @@
 #ifndef LIMBO_OPT_HPP
 #define LIMBO_OPT_HPP
 
+#ifdef USE_LIBCMAES
 #include <limbo/opt/cmaes.hpp>
+#endif
 #include <limbo/opt/grid_search.hpp>
 #ifdef USE_NLOPT
 #include <limbo/opt/nlopt_grad.hpp>

--- a/src/tests/wscript
+++ b/src/tests/wscript
@@ -15,13 +15,13 @@ def build(bld):
                 source='test_gp.cpp',
                 includes='. .. ../../',
                 target='test_gp',
-                uselib='BOOST EIGEN TBB LIBCMAES',
+                uselib='BOOST EIGEN TBB',
                 use='limbo')
     bld.program(features='cxx test',
                 source='test_init_functions.cpp',
                 includes='. .. ../../',
                 target='test_init_functions',
-                uselib='BOOST EIGEN TBB LIBCMAES',
+                uselib='BOOST EIGEN TBB',
                 use='limbo')
     bld.program(features='cxx test',
                 source='test_optimizers.cpp',
@@ -33,22 +33,22 @@ def build(bld):
                 source='test_macros.cpp',
                 includes='. .. ../../',
                 target='test_macros',
-                uselib='BOOST EIGEN TBB LIBCMAES',
+                uselib='BOOST EIGEN TBB',
                 use='limbo')
     bld.program(features='cxx',
                 source='boptimizer.cpp',
                 includes='. .. ../../',
                 target='boptimizer',
-                uselib='BOOST EIGEN TBB SFERES LIBCMAES',
+                uselib='BOOST EIGEN TBB LIBCMAES',
                 use='limbo')
     if bld.env.DEFINES_NLOPT:
         bld.program(features='cxx test',
                     source='test_nlopt.cpp',
                     includes='. .. ../../',
                     target='test_nlopt',
-                    uselib='BOOST EIGEN TBB NLOPT LIBCMAES',
+                    uselib='BOOST EIGEN TBB NLOPT',
                     use='limbo')
-    if bld.env.DEFINES_NLOPT:
+    if bld.env.DEFINES_LIBCMAES:
         bld.program(features='cxx test',
                     source='test_cmaes.cpp',
                     includes='. .. ../../',


### PR DESCRIPTION
- Conditionally including NLOpt and CMAES headers in the opt.hpp header and in bo_base
- Conditionally including the multi objective optimizers in bayes_opt.hpp if USE_SFERES is defined
- Fixed typo in the declaration of the default acqui optimizer when using NLOPT. Also fixed the algorithm constant
- Removed unnecesary dependencies in the tests wscript