### PR TITLE
Multiple configs in json for OAR/Torque

### DIFF
--- a/waf_tools/limbo.py
+++ b/waf_tools/limbo.py
@@ -71,57 +71,59 @@ def _sub_script(tpl, conf_file):
         ld_lib_path = "''"
     print 'LD_LIBRARY_PATH=' + ld_lib_path
      # parse conf
-    conf = simplejson.load(open(conf_file))
-    exps = conf['exps']
-    nb_runs = conf['nb_runs']
-    res_dir = conf['res_dir']
-    bin_dir = conf['bin_dir']
-    wall_time = conf['wall_time']
-    use_mpi = "false"
-    try:
-        use_mpi = conf['use_mpi']
-    except:
-        use_mpi = "false"
-    try:
-        nb_cores = conf['nb_cores']
-    except:
-        nb_cores = 1
-    try:
-        args = conf['args']
-    except:
-        args = ''
-    email = conf['email']
-    if (use_mpi == "true"):
-        ppn = '1'
-        mpirun = 'mpirun'
-    else:
- #      nb_cores = 1;
-        ppn = "8"
-        mpirun = ''
-
+    list_exps = simplejson.load(open(conf_file))
     fnames = []
-    for i in range(0, nb_runs):
-        for e in exps:
-            directory = res_dir + "/" + e + "/exp_" + str(i)
-            try:
-                os.makedirs(directory)
-            except:
-                print "WARNING, dir:" + directory + " not be created"
-            subprocess.call('cp ' + bin_dir + '/' + e + ' ' + directory, shell=True)
-            fname = directory + "/" + e + "_" + str(i) + ".job"
-            f = open(fname, "w")
-            f.write(tpl
-                    .replace("@exp", e)
-                    .replace("@email", email)
-                    .replace("@ld_lib_path", ld_lib_path)
-                    .replace("@wall_time", wall_time)
-                    .replace("@dir", directory)
-                    .replace("@nb_cores", str(nb_cores))
-                    .replace("@ppn", ppn)
-                    .replace("@exec", mpirun + ' ' + directory + '/' + e + ' ' + args))
-            f.close()
-            os.chmod(fname, stat.S_IEXEC | stat.S_IREAD | stat.S_IWRITE)
-            fnames += [(fname, directory)]
+    for conf in list_exps:
+        exps = conf['exps']
+        nb_runs = conf['nb_runs']
+        res_dir = conf['res_dir']
+        bin_dir = conf['bin_dir']
+        wall_time = conf['wall_time']
+        use_mpi = "false"
+        try:
+            use_mpi = conf['use_mpi']
+        except:
+            use_mpi = "false"
+        try:
+            nb_cores = conf['nb_cores']
+        except:
+            nb_cores = 1
+        try:
+            args = conf['args']
+        except:
+            args = ''
+        email = conf['email']
+        if (use_mpi == "true"):
+            ppn = '1'
+            mpirun = 'mpirun'
+        else:
+     #      nb_cores = 1;
+            ppn = "8"
+            mpirun = ''
+
+        #fnames = []
+        for i in range(0, nb_runs):
+            for e in exps:
+                directory = res_dir + "/" + e + "/exp_" + str(i)
+                try:
+                    os.makedirs(directory)
+                except:
+                    print "WARNING, dir:" + directory + " not be created"
+                subprocess.call('cp ' + bin_dir + '/' + e + ' ' + directory, shell=True)
+                fname = directory + "/" + e + "_" + str(i) + ".job"
+                f = open(fname, "w")
+                f.write(tpl
+                        .replace("@exp", e)
+                        .replace("@email", email)
+                        .replace("@ld_lib_path", ld_lib_path)
+                        .replace("@wall_time", wall_time)
+                        .replace("@dir", directory)
+                        .replace("@nb_cores", str(nb_cores))
+                        .replace("@ppn", ppn)
+                        .replace("@exec", mpirun + ' ' + directory + '/' + e + ' ' + args))
+                f.close()
+                os.chmod(fname, stat.S_IEXEC | stat.S_IREAD | stat.S_IWRITE)
+                fnames += [(fname, directory)]
     return fnames
 
 


### PR DESCRIPTION
Small improvement: **Multiple configs in json for OAR/Torque**.

Now we can do this:

```json
[{
 "exps" : ["test_exp_name"],
 "bin_dir" : "/home/test_binary_dir",
 "res_dir" : "/home/test_result_dir",
 "args" : "argument1 argument2",
 "email" : "myname@email.com",
 "wall_time" : "00:03:00",
 "nb_runs" : 100,
 "nb_cores" : 2
},

{
 "exps" : ["test_exp_name"],
 "bin_dir" : "/home/test_binary_dir",
 "res_dir" : "/home/different_test_result_dir",
 "args" : "different_argument1 differet_argument2",
 "email" : "myname@email.com",
 "wall_time" : "00:03:00",
 "nb_runs" : 100,
 "nb_cores" : 2
}]
```

Where as before we would need 2 different json files. We can still have only 1 config like this:

```json
[{
 "exps" : ["test_exp_name"],
 "bin_dir" : "/home/test_binary_dir",
 "res_dir" : "/home/test_result_dir",
 "args" : "argument1 argument2",
 "email" : "myname@email.com",
 "wall_time" : "00:03:00",
 "nb_runs" : 100,
 "nb_cores" : 2
}]
```