### PR TITLE
BOptimizer stop check fix

### DIFF
--- a/src/limbo/bayes_opt/boptimizer.hpp
+++ b/src/limbo/bayes_opt/boptimizer.hpp
@@ -72,7 +72,7 @@ namespace limbo {
 
                 acqui_optimizer_t acqui_optimizer;
 
-                while (this->_samples.size() == 0 || !this->_stop(*this, afun)) {
+                while (!this->_stop(*this, afun)) {
                     acquisition_function_t acqui(_model, this->_current_iteration);
 
                     // we do not have gradient in our current acquisition function


### PR DESCRIPTION
No need to check for samples size in boptimizer loop.. This is probably left from older versions. Now everything is checked (and should be) in the stop criteria.