### PR TITLE
Allow multiple source files in variants

### DIFF
--- a/waf_tools/limbo.py
+++ b/waf_tools/limbo.py
@@ -18,8 +18,9 @@ def create_variants(bld, source, uselib_local,
                     uselib, variants, includes=". ../",
                     cxxflags='',
                     target=''):
+    source_list = source.split()
     if not target:
-        tmp = source.replace('.cpp', '')
+        tmp = source_list[0].replace('.cpp', '')
     else:
         tmp = target
     for v in variants:


### PR DESCRIPTION
Allow multiple source files in variants. First file is the file that the variant target take the name from. For example now you can do this:

```python
limbo.create_variants(bld,
                          source = 'hexa_repertoire.cpp test.cpp',
                          uselib_local = 'limbo',
                          uselib = libs,
                          includes=". ../../src ../ ",
                          cxxflags = cxxflags,
                          variants = ['SIMU'])
```

The target created would be `hexa_repertoire_simu`.
