### PR TITLE
Gp nodim

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
- *~
+*~
+*#
 .DS_Store
 .project
 .settings

--- a/src/limbo/bayes_opt/boptimizer.hpp
+++ b/src/limbo/bayes_opt/boptimizer.hpp
@@ -64,7 +64,7 @@ namespace limbo {
             template <typename StateFunction, typename AggregatorFunction = FirstElem>
             void optimize(const StateFunction& sfun, const AggregatorFunction& afun = AggregatorFunction(), bool reset = true)
             {
-                _model = model_t(StateFunction::dim_in, StateFunction::dim_out);
+	      
                 this->_init(sfun, afun, reset);
 
                 if (!this->_observations.empty())

--- a/src/limbo/model/gp.hpp
+++ b/src/limbo/model/gp.hpp
@@ -19,10 +19,7 @@ namespace limbo {
         class GP {
         public:
             GP() : _dim_in(-1), _dim_out(-1) {}
-            // useful because the model might be created  before having samples
-	  //GP(int dim_in, int dim_out)
-	  //    : _dim_in(dim_in), _dim_out(dim_out), _kernel_function(dim_in), _mean_function(dim_out) {}
-
+            
             void compute(const std::vector<Eigen::VectorXd>& samples,
                 const std::vector<Eigen::VectorXd>& observations, double noise,
                 const std::vector<Eigen::VectorXd>& bl_samples = std::vector<Eigen::VectorXd>())

--- a/src/limbo/model/gp.hpp
+++ b/src/limbo/model/gp.hpp
@@ -20,24 +20,32 @@ namespace limbo {
         public:
             GP() : _dim_in(-1), _dim_out(-1) {}
             // useful because the model might be created  before having samples
-            GP(int dim_in, int dim_out)
-                : _dim_in(dim_in), _dim_out(dim_out), _kernel_function(dim_in), _mean_function(dim_out) {}
+	  //GP(int dim_in, int dim_out)
+	  //    : _dim_in(dim_in), _dim_out(dim_out), _kernel_function(dim_in), _mean_function(dim_out) {}
 
             void compute(const std::vector<Eigen::VectorXd>& samples,
                 const std::vector<Eigen::VectorXd>& observations, double noise,
                 const std::vector<Eigen::VectorXd>& bl_samples = std::vector<Eigen::VectorXd>())
             {
-                if (_dim_in == -1) {
-                    assert(samples.size() != 0);
-                    assert(observations.size() != 0);
-                    assert(samples.size() == observations.size());
-                    _dim_in = samples[0].size();
-                    _dim_out = observations[0].size();
-                }
+	      //should be checked each time! not only the first time
+	      assert(samples.size() != 0); 
+	      assert(observations.size() != 0);
+	      assert(samples.size() == observations.size());
+	                    
+	      if(_dim_in != samples[0].size())
+		{
+		  _dim_in = samples[0].size();
+		  _kernel_function=KernelFunction(_dim_in);   // the cost of building a functor should be relatively low
+		}
 
+	      if(_dim_out != observations[0].size())
+		{
+		  _dim_out = observations[0].size(); 
+		  _mean_function = MeanFunction(_dim_out);  // the cost of building a functor should be relatively low
+		}
+	      
                 _samples = samples;
-
-                _observations.resize(observations.size(), observations[0].size());
+                _observations.resize(observations.size(), _dim_out);
                 for (int i = 0; i < _observations.rows(); ++i)
                     _observations.row(i) = observations[i];
 


### PR DESCRIPTION
Small bug fix:
Using the default constructor of GP imposes the dim_in and dim_out to be 1 for kernel and mean functions (because default constructors are called too) even if the dims are supposed to be automatically determined when computing the data. However, the new value of dim_in and dim_out are not propagated to kernel and mean functions, which results in an assert when computing multi-dimensional data with a gp built via the default constructor.

This branch improves the way the dims are automatically determined, removing the need of specifying the dims in the constructor.
I added a small test in test_gp.cpp to check that building multidimensional gp with the default constructor works well (this test raises an assert from Eigen with the current version of master). 

Moreover, the asserts regarding size of the data should be check every time, not only in the first call of "compute".

Minor improvement of .gitignore