### PR TITLE
Fix for gp nodim bug

### DIFF
--- a/src/limbo/bayes_opt/boptimizer.hpp
+++ b/src/limbo/bayes_opt/boptimizer.hpp
@@ -64,11 +64,13 @@ namespace limbo {
             template <typename StateFunction, typename AggregatorFunction = FirstElem>
             void optimize(const StateFunction& sfun, const AggregatorFunction& afun = AggregatorFunction(), bool reset = true)
             {
-	      
+
                 this->_init(sfun, afun, reset);
 
                 if (!this->_observations.empty())
                     _model.compute(this->_samples, this->_observations, Params::bayes_opt_boptimizer::noise(), this->_bl_samples);
+                else
+                    _model = model_t(StateFunction::dim_in, StateFunction::dim_out);
 
                 acqui_optimizer_t acqui_optimizer;
 

--- a/src/limbo/model/gp.hpp
+++ b/src/limbo/model/gp.hpp
@@ -19,28 +19,30 @@ namespace limbo {
         class GP {
         public:
             GP() : _dim_in(-1), _dim_out(-1) {}
-            
+
+            // useful because the model might be created  before having samples
+            GP(int dim_in, int dim_out)
+                : _dim_in(dim_in), _dim_out(dim_out), _kernel_function(dim_in), _mean_function(dim_out) {}
+
             void compute(const std::vector<Eigen::VectorXd>& samples,
                 const std::vector<Eigen::VectorXd>& observations, double noise,
                 const std::vector<Eigen::VectorXd>& bl_samples = std::vector<Eigen::VectorXd>())
             {
-	      //should be checked each time! not only the first time
-	      assert(samples.size() != 0); 
-	      assert(observations.size() != 0);
-	      assert(samples.size() == observations.size());
-	                    
-	      if(_dim_in != samples[0].size())
-		{
-		  _dim_in = samples[0].size();
-		  _kernel_function=KernelFunction(_dim_in);   // the cost of building a functor should be relatively low
-		}
+                //should be checked each time! not only the first time
+                assert(samples.size() != 0);
+                assert(observations.size() != 0);
+                assert(samples.size() == observations.size());
 
-	      if(_dim_out != observations[0].size())
-		{
-		  _dim_out = observations[0].size(); 
-		  _mean_function = MeanFunction(_dim_out);  // the cost of building a functor should be relatively low
-		}
-	      
+                if (_dim_in != samples[0].size()) {
+                    _dim_in = samples[0].size();
+                    _kernel_function = KernelFunction(_dim_in); // the cost of building a functor should be relatively low
+                }
+
+                if (_dim_out != observations[0].size()) {
+                    _dim_out = observations[0].size();
+                    _mean_function = MeanFunction(_dim_out); // the cost of building a functor should be relatively low
+                }
+
                 _samples = samples;
                 _observations.resize(observations.size(), _dim_out);
                 for (int i = 0; i < _observations.rows(); ++i)


### PR DESCRIPTION
#84 produced a bug when calling the BOptimizer. So, I re-enabled the dimensions in GP's constructor and altered BOptimizer to properly handle the cases.

The test "boptimizer" was failing with assertions. I, also, created a new gp test for this specific case.

Thanks @vassilisvas for pointing the bug out.