### PR TITLE
Chained Optimizer

### DIFF
--- a/src/limbo/opt.hpp
+++ b/src/limbo/opt.hpp
@@ -2,6 +2,7 @@
 #define LIMBO_OPT_HPP
 
 #include <limbo/opt/optimizer.hpp>
+#include <limbo/opt/chained.hpp>
 #ifdef USE_LIBCMAES
 #include <limbo/opt/cmaes.hpp>
 #endif

--- a/src/limbo/opt/chained.hpp
+++ b/src/limbo/opt/chained.hpp
@@ -1,0 +1,38 @@
+#ifndef LIMBO_OPT_CHAINED_HPP
+#define LIMBO_OPT_CHAINED_HPP
+
+#include <algorithm>
+
+#include <Eigen/Core>
+
+#include <limbo/opt/optimizer.hpp>
+
+namespace limbo {
+    namespace opt {
+
+        // Needed for the variadic data structure
+        template <typename Params, typename... Optimizers> struct Chained {};
+
+        // Base case: just 1 optimizer to call
+        template <typename Params, typename Optimizer>
+        struct Chained<Params, Optimizer> {
+            template <typename F>
+            Eigen::VectorXd operator()(const F& f, const Eigen::VectorXd& init, bool bounded) const
+            {
+                return Optimizer()(f, init, bounded);
+            };
+        };
+
+        // Recursive case: call current optimizer, and pass result as init value for the next one
+        template <typename Params, typename Optimizer, typename... Optimizers>
+        struct Chained<Params, Optimizer, Optimizers...> : Chained<Params, Optimizers...> {
+            template <typename F>
+            Eigen::VectorXd operator()(const F& f, const Eigen::VectorXd& init, bool bounded) const
+            {
+                return Chained<Params, Optimizers...>::operator ()(f, Optimizer()(f, init, bounded), bounded);
+            };
+        };
+    }
+}
+
+#endif

--- a/src/tests/test_optimizers.cpp
+++ b/src/tests/test_optimizers.cpp
@@ -7,6 +7,7 @@
 #include <limbo/opt/cmaes.hpp>
 #include <limbo/opt/grid_search.hpp>
 #include <limbo/opt/random_point.hpp>
+#include <limbo/opt/chained.hpp>
 
 using namespace limbo;
 
@@ -103,4 +104,23 @@ BOOST_AUTO_TEST_CASE(test_grid_search_bi_dim)
     BOOST_CHECK_SMALL(best_point(1), 0.000001);
     // TO-DO: Maybe alter a little grid search so not to call more times the utility function
     BOOST_CHECK_EQUAL(bidim_calls, (Params::opt_gridsearch::bins() + 1) * (Params::opt_gridsearch::bins() + 1) + 21);
+}
+
+BOOST_AUTO_TEST_CASE(test_chained)
+{
+    using namespace limbo;
+
+    typedef opt::GridSearch<Params> opt_1_t;
+    typedef opt::RandomPoint<Params> opt_2_t;
+    typedef opt::GridSearch<Params> opt_3_t;
+    typedef opt::GridSearch<Params> opt_4_t;
+    opt::Chained<Params, opt_1_t, opt_2_t, opt_3_t, opt_4_t> optimizer;
+
+    monodim_calls = 0;
+    Eigen::VectorXd best_point = optimizer(acqui_mono, Eigen::VectorXd::Constant(1, 0.5), true);
+
+    BOOST_CHECK_EQUAL(best_point.size(), 1);
+    BOOST_CHECK(best_point(0) > 0 || std::abs(best_point(0)) < 1e-7);
+    BOOST_CHECK(best_point(0) < 1 || std::abs(best_point(0) - 1) < 1e-7);
+    BOOST_CHECK_EQUAL(monodim_calls, (Params::opt_gridsearch::bins() + 1) * 3);
 }


### PR DESCRIPTION
Hi guys! 
I implemented the `Chained` optimizer, something I think I might have discussed with some of you when speaking of BayesOpt.
I did it using variadic templates (instead of using maybe Boost's Fusion Vectors) because it is super easy and straightforward. 
I also added a test, and checked that things are called in the right order(using the awesome `typeid(T).name()` feature).

Here I show you an approximate example of doing what BayesOpt does:
```
struct ParamsDIRECT {
    struct opt_nloptnograd {
        BO_PARAM(int, iterations, (500 * F_DIM * 0.9)); // This may give compiler error, you can change it if you want
    };
};

struct ParamsBOBYQA {
    struct opt_nloptnograd {
        BO_PARAM(int, iterations, (500 * F_DIM * 0.1)); // Same here
    };
};

struct Params {
....
};

...

typedef opt::Chained<Params, opt::NLOptNoGrad<ParamsDIRECT, nlopt::GN_DIRECT_L>, opt::NLOptNoGrad<ParamsBOBYQA , nlopt::LN_BOBYQA>> acqui_opt;

```

The need to specify different parameter structs is not because of the chained optimizer, it's because of the `NLOptNoGrad`, on which we need to specify different amount of iterations for DIRECT and BOBYQA. Also, `F_DIM ` is there because they multiply 500 by the input dimension of the objective function.

Regards!