### PR TITLE
Remove the optimization of the unused HP in SE_ARD

### DIFF
--- a/src/limbo/kernel/squared_exp_ard.hpp
+++ b/src/limbo/kernel/squared_exp_ard.hpp
@@ -50,7 +50,6 @@ namespace limbo {
                 for (size_t j = 0; j < (unsigned int)Params::kernel_squared_exp_ard::k(); ++j)
                     for (size_t i = 0; i < _input_dim; ++i)
                         _A(i, j) = p((j + 1) * _input_dim + i); //can be negative
-                // _sf2 = 1; // exp(2 * p(p.size()-1));
             }
 
             Eigen::VectorXd grad(const Eigen::VectorXd& x1, const Eigen::VectorXd& x2) const
@@ -67,7 +66,6 @@ namespace limbo {
                     for (size_t j = 0; j < Params::kernel_squared_exp_ard::k(); ++j)
                         grad.segment((1 + j) * _input_dim, _input_dim) = G.col(j);
 
-                    //grad(this->h_params_size() - 1) = 0; // 2.0 * k;
                     return grad;
                 }
                 else {
@@ -75,7 +73,6 @@ namespace limbo {
                     Eigen::VectorXd z = (x1 - x2).cwiseQuotient(_ell).array().square();
                     double k = _sf2 * std::exp(-0.5 * z.sum());
                     grad.head(_input_dim) = z * k;
-                    //grad(_input_dim) = 0; // 2.0 * k;
                     return grad;
                 }
             }

--- a/src/limbo/kernel/squared_exp_ard.hpp
+++ b/src/limbo/kernel/squared_exp_ard.hpp
@@ -32,13 +32,13 @@ namespace limbo {
             SquaredExpARD(int dim = 1) : _sf2(0), _ell(dim), _A(dim, Params::kernel_squared_exp_ard::k()), _input_dim(dim)
             {
                 //assert(Params::SquaredExpARD::k()<dim);
-                Eigen::VectorXd p = Eigen::VectorXd::Zero(_ell.size() + _ell.size() * Params::kernel_squared_exp_ard::k() + 1);
+                Eigen::VectorXd p = Eigen::VectorXd::Zero(_ell.size() + _ell.size() * Params::kernel_squared_exp_ard::k());
                 p.head(_ell.size()) = Eigen::VectorXd::Ones(_ell.size()) * -1;
                 this->set_h_params(p);
                 _sf2 = Params::kernel_squared_exp_ard::sigma_sq();
             }
 
-            size_t h_params_size() const { return _ell.size() + _ell.size() * Params::kernel_squared_exp_ard::k() + 1; }
+            size_t h_params_size() const { return _ell.size() + _ell.size() * Params::kernel_squared_exp_ard::k(); }
 
             const Eigen::VectorXd& h_params() const { return _h_params; }
 
@@ -67,15 +67,15 @@ namespace limbo {
                     for (size_t j = 0; j < Params::kernel_squared_exp_ard::k(); ++j)
                         grad.segment((1 + j) * _input_dim, _input_dim) = G.col(j);
 
-                    grad(this->h_params_size() - 1) = 0; // 2.0 * k;
+                    //grad(this->h_params_size() - 1) = 0; // 2.0 * k;
                     return grad;
                 }
                 else {
-                    Eigen::VectorXd grad(_input_dim + 1);
+                    Eigen::VectorXd grad(_input_dim);
                     Eigen::VectorXd z = (x1 - x2).cwiseQuotient(_ell).array().square();
                     double k = _sf2 * std::exp(-0.5 * z.sum());
                     grad.head(_input_dim) = z * k;
-                    grad(_input_dim) = 0; // 2.0 * k;
+                    //grad(_input_dim) = 0; // 2.0 * k;
                     return grad;
                 }
             }

--- a/src/tests/test_gp.cpp
+++ b/src/tests/test_gp.cpp
@@ -3,7 +3,6 @@
 
 #include <boost/test/unit_test.hpp>
 
-
 #include <limbo/acqui/ucb.hpp>
 #include <limbo/kernel/matern_five_halfs.hpp>
 #include <limbo/kernel/matern_three_halfs.hpp>

--- a/src/tests/test_gp.cpp
+++ b/src/tests/test_gp.cpp
@@ -3,6 +3,7 @@
 
 #include <boost/test/unit_test.hpp>
 
+
 #include <limbo/acqui/ucb.hpp>
 #include <limbo/kernel/matern_five_halfs.hpp>
 #include <limbo/kernel/matern_three_halfs.hpp>

--- a/src/tests/test_kernel.cpp
+++ b/src/tests/test_kernel.cpp
@@ -31,7 +31,7 @@ BOOST_AUTO_TEST_CASE(test_kernel_SE_ARD)
     Eigen::VectorXd hp(se.h_params_size());
     hp(0) = 0; //exp(0)=1
     hp(1) = 0;
-    hp(2) = 1;
+
     se.set_h_params(hp);
 
     Eigen::VectorXd v1 = make_v2(1, 1);
@@ -54,7 +54,7 @@ BOOST_AUTO_TEST_CASE(test_kernel_SE_ARD)
     hp(1) = 0;
     hp(2) = 0;
     hp(3) = 0;
-    hp(4) = 1;
+    
 
     se.set_h_params(hp);
     BOOST_CHECK(s1 == se(v1, v2));

--- a/src/tests/test_kernel.cpp
+++ b/src/tests/test_kernel.cpp
@@ -54,7 +54,6 @@ BOOST_AUTO_TEST_CASE(test_kernel_SE_ARD)
     hp(1) = 0;
     hp(2) = 0;
     hp(3) = 0;
-    
 
     se.set_h_params(hp);
     BOOST_CHECK(s1 == se(v1, v2));


### PR DESCRIPTION
If the CI passes, ready to be merged.
(and the benchmarks to be relaunched)
