### PR TITLE
fix typos in names of the benchmark function

### DIFF
--- a/src/benchmarks/bayesopt/hp_opt.cpp
+++ b/src/benchmarks/bayesopt/hp_opt.cpp
@@ -48,12 +48,12 @@ int main(int nargs, char* args[])
     strcpy(par.kernel.name, "kSEARD");
 
     benchmark<BraninNormalized>(par, "branin");
-    benchmark<Hartman6>(par, "hartman6");
-    benchmark<Hartman3>(par, "hartman3");
+    benchmark<Hartmann6>(par, "hartmann6");
+    benchmark<Hartmann3>(par, "hartmann3");
     benchmark<Rastrigin>(par, "rastrigin");
     benchmark<Sphere>(par, "sphere");
     benchmark<Ellipsoid>(par, "ellipsoid");
-    benchmark<GoldenPrice>(par, "goldenprice");
+    benchmark<GoldsteinPrice>(par, "goldsteinprice");
     benchmark<SixHumpCamel>(par, "sixhumpcamel");
 
     return 0;

--- a/src/benchmarks/bayesopt/simple.cpp
+++ b/src/benchmarks/bayesopt/simple.cpp
@@ -48,12 +48,12 @@ int main(int nargs, char* args[])
     strcpy(par.kernel.name, "kMaternISO5");
 
     benchmark<BraninNormalized>(par, "branin");
-    benchmark<Hartman6>(par, "hartman6");
-    benchmark<Hartman3>(par, "hartman3");
+    benchmark<Hartmann6>(par, "hartmann6");
+    benchmark<Hartmann3>(par, "hartmann3");
     benchmark<Rastrigin>(par, "rastrigin");
     benchmark<Sphere>(par, "sphere");
     benchmark<Ellipsoid>(par, "ellipsoid");
-    benchmark<GoldenPrice>(par, "goldenprice");
+    benchmark<GoldsteinPrice>(par, "goldsteinprice");
     benchmark<SixHumpCamel>(par, "sixhumpcamel");
 
     return 0;

--- a/src/benchmarks/bayesopt/testfunctions.hpp
+++ b/src/benchmarks/bayesopt/testfunctions.hpp
@@ -138,7 +138,7 @@ struct Rastrigin {
 };
 
 // see : http://www.sfu.ca/~ssurjano/hart3.html
-struct Hartman3 {
+struct Hartmann3 {
     static constexpr size_t dim_in = 3;
     static constexpr size_t dim_out = 1;
 
@@ -172,7 +172,7 @@ struct Hartman3 {
 };
 
 // see : http://www.sfu.ca/~ssurjano/hart6.html
-struct Hartman6 {
+struct Hartmann6 {
     static constexpr size_t dim_in = 6;
     static constexpr size_t dim_out = 1;
 
@@ -210,7 +210,7 @@ struct Hartman6 {
 
 // see : http://www.sfu.ca/~ssurjano/goldpr.html
 // (with ln, as suggested in Jones et al.)
-struct GoldenPrice {
+struct GoldsteinPrice {
     static constexpr size_t dim_in = 2;
     static constexpr size_t dim_out = 1;
 

--- a/src/benchmarks/limbo/hp_opt.cpp
+++ b/src/benchmarks/limbo/hp_opt.cpp
@@ -105,12 +105,12 @@ int main()
     typedef bayes_opt::BOptimizer<Params, modelfun<GP_t>, initfun<Init_t>, acquifun<Acqui_t>, acquiopt<AcquiOpt_t>, statsfun<Stat_t>, stopcrit<Stop_t>> Opt_t;
 
     benchmark<Opt_t, BraninNormalized>("branin");
-    benchmark<Opt_t, Hartman6>("hartman6");
-    benchmark<Opt_t, Hartman3>("hartman3");
+    benchmark<Opt_t, Hartmann6>("hartmann6");
+    benchmark<Opt_t, Hartmann3>("hartmann3");
     benchmark<Opt_t, Rastrigin>("rastrigin");
     benchmark<Opt_t, Sphere>("sphere");
     benchmark<Opt_t, Ellipsoid>("ellipsoid");
-    benchmark<Opt_t, GoldenPrice>("goldenprice");
+    benchmark<Opt_t, GoldsteinPrice>("goldsteinprice");
     benchmark<Opt_t, SixHumpCamel>("sixhumpcamel");
 
     return 0;

--- a/src/benchmarks/limbo/simple.cpp
+++ b/src/benchmarks/limbo/simple.cpp
@@ -80,7 +80,7 @@ int main()
 {
     srand(time(NULL));
 
-    typedef kernel::MaternFiveHalfs<Params> Kernel_t;
+    typedef kernel::MaternFiveHalves<Params> Kernel_t;
     typedef opt::Chained<Params, opt::NLOptNoGrad<DirectParams, nlopt::GN_DIRECT_L>, opt::NLOptNoGrad<BobyqaParams, nlopt::LN_BOBYQA>> AcquiOpt_t;
     typedef boost::fusion::vector<stop::MaxIterations<Params>> Stop_t;
     // typedef mean_functions::MeanFunctionARD<Params, mean_functions::MeanData<Params>> Mean_t;

--- a/src/benchmarks/limbo/simple.cpp
+++ b/src/benchmarks/limbo/simple.cpp
@@ -93,12 +93,12 @@ int main()
     typedef bayes_opt::BOptimizer<Params, modelfun<GP_t>, initfun<Init_t>, acquifun<Acqui_t>, acquiopt<AcquiOpt_t>, statsfun<Stat_t>, stopcrit<Stop_t>> Opt_t;
 
     benchmark<Opt_t, BraninNormalized>("branin");
-    benchmark<Opt_t, Hartman6>("hartman6");
-    benchmark<Opt_t, Hartman3>("hartman3");
+    benchmark<Opt_t, Hartmann6>("hartmann6");
+    benchmark<Opt_t, Hartmann3>("hartmann3");
     benchmark<Opt_t, Rastrigin>("rastrigin");
     benchmark<Opt_t, Sphere>("sphere");
     benchmark<Opt_t, Ellipsoid>("ellipsoid");
-    benchmark<Opt_t, GoldenPrice>("goldenprice");
+    benchmark<Opt_t, GoldsteinPrice>("goldsteinprice");
     benchmark<Opt_t, SixHumpCamel>("sixhumpcamel");
 
     return 0;

--- a/src/benchmarks/limbo/testfunctions.hpp
+++ b/src/benchmarks/limbo/testfunctions.hpp
@@ -110,7 +110,7 @@ struct Rastrigin {
 };
 
 // see : http://www.sfu.ca/~ssurjano/hart3.html
-struct Hartman3 {
+struct Hartmann3 {
     static constexpr size_t dim_in = 3;
     static constexpr size_t dim_out = 1;
 
@@ -144,7 +144,7 @@ struct Hartman3 {
 };
 
 // see : http://www.sfu.ca/~ssurjano/hart6.html
-struct Hartman6 {
+struct Hartmann6 {
     static constexpr size_t dim_in = 6;
     static constexpr size_t dim_out = 1;
 
@@ -182,7 +182,7 @@ struct Hartman6 {
 
 // see : http://www.sfu.ca/~ssurjano/goldpr.html
 // (with ln, as suggested in Jones et al.)
-struct GoldenPrice {
+struct GoldsteinPrice {
     static constexpr size_t dim_in = 2;
     static constexpr size_t dim_out = 1;
 

--- a/src/examples/mono_dim.cpp
+++ b/src/examples/mono_dim.cpp
@@ -67,7 +67,7 @@ struct fit_eval {
 
 int main()
 {
-    typedef kernel::MaternFiveHalfs<Params> Kernel_t;
+    typedef kernel::MaternFiveHalves<Params> Kernel_t;
     typedef mean::Data<Params> Mean_t;
     typedef model::GP<Params, Kernel_t, Mean_t> GP_t;
     typedef acqui::UCB<Params, GP_t> Acqui_t;

--- a/src/examples/obs_multi.cpp
+++ b/src/examples/obs_multi.cpp
@@ -74,7 +74,7 @@ struct SecondElem {
 
 int main()
 {
-    typedef kernel::MaternFiveHalfs<Params> Kernel_t;
+    typedef kernel::MaternFiveHalves<Params> Kernel_t;
     typedef mean::Data<Params> Mean_t;
     typedef model::GP<Params, Kernel_t, Mean_t> GP_t;
     typedef acqui::GP_UCB<Params, GP_t> Acqui_t;

--- a/src/limbo/bayes_opt/bo_base.hpp
+++ b/src/limbo/bayes_opt/bo_base.hpp
@@ -122,7 +122,7 @@ namespace limbo {
         For Statistics, the default value is: ``boost::fusion::vector<stat::Samples<Params>, stat::AggregatedObservations<Params>, stat::ConsoleSummary<Params>>``
 
         Example of customization:
-          - ``typedef kernel::MaternFiveHalfs<Params> Kernel_t;``
+          - ``typedef kernel::MaternFiveHalves<Params> Kernel_t;``
           - ``typedef mean::Data<Params> Mean_t;``
           - ``typedef model::GP<Params, Kernel_t, Mean_t> GP_t;``
           - ``typedef acqui::UCB<Params, GP_t> Acqui_t;``

--- a/src/limbo/kernel/matern_five_halfs.hpp
+++ b/src/limbo/kernel/matern_five_halfs.hpp
@@ -38,8 +38,8 @@ namespace limbo {
           \endrst
         */
         template <typename Params>
-        struct MaternFiveHalfs {
-            MaternFiveHalfs(size_t dim = 1) {}
+        struct MaternFiveHalves {
+            MaternFiveHalves(size_t dim = 1) {}
 
             double operator()(const Eigen::VectorXd& v1, const Eigen::VectorXd& v2) const
             {

--- a/src/limbo/kernel/matern_three_halfs.hpp
+++ b/src/limbo/kernel/matern_three_halfs.hpp
@@ -37,8 +37,8 @@ namespace limbo {
         \endrst
         */
         template <typename Params>
-        struct MaternThreeHalfs {
-            MaternThreeHalfs(size_t dim = 1) {}
+        struct MaternThreeHalves {
+            MaternThreeHalves(size_t dim = 1) {}
 
             double operator()(const Eigen::VectorXd& v1, const Eigen::VectorXd& v2) const
             {

--- a/src/tests/create_all_combinations_test.py
+++ b/src/tests/create_all_combinations_test.py
@@ -6,11 +6,11 @@ import os
 
 
 def create(bld):
-    kernels = ['Exp', 'MaternThreeHalfs', 'MaternFiveHalfs', 'SquaredExpARD']
+    kernels = ['Exp', 'MaternThreeHalves', 'MaternFiveHalves', 'SquaredExpARD']
     kernel_incompatibility = {}
     kernel_incompatibility['Exp'] = ['KernelLFOpt', 'KernelMeanLFOpt', 'MeanLFOpt']
-    kernel_incompatibility['MaternThreeHalfs'] = ['KernelLFOpt', 'KernelMeanLFOpt', 'MeanLFOpt']
-    kernel_incompatibility['MaternFiveHalfs'] = ['KernelLFOpt', 'KernelMeanLFOpt', 'MeanLFOpt']
+    kernel_incompatibility['MaternThreeHalves'] = ['KernelLFOpt', 'KernelMeanLFOpt', 'MeanLFOpt']
+    kernel_incompatibility['MaternFiveHalves'] = ['KernelLFOpt', 'KernelMeanLFOpt', 'MeanLFOpt']
 
     means = ['NullFunction', 'Constant', 'Data', 'FunctionARD']
     mean_additional_params = {}

--- a/src/tests/test_gp.cpp
+++ b/src/tests/test_gp.cpp
@@ -57,7 +57,7 @@ BOOST_AUTO_TEST_CASE(test_gp_dim)
 {
     using namespace limbo;
 
-    typedef kernel::MaternFiveHalfs<Params> KF_t;
+    typedef kernel::MaternFiveHalves<Params> KF_t;
     typedef mean::Constant<Params> Mean_t;
     typedef model::GP<Params, KF_t, Mean_t> GP_t;
 
@@ -82,7 +82,7 @@ BOOST_AUTO_TEST_CASE(test_gp)
 {
     using namespace limbo;
 
-    typedef kernel::MaternFiveHalfs<Params> KF_t;
+    typedef kernel::MaternFiveHalves<Params> KF_t;
     typedef mean::Constant<Params> Mean_t;
     typedef model::GP<Params, KF_t, Mean_t> GP_t;
 
@@ -124,7 +124,7 @@ BOOST_AUTO_TEST_CASE(test_gp_bw_inversion)
     size_t N = 1000;
     size_t failures = 0;
 
-    typedef kernel::MaternFiveHalfs<Params> KF_t;
+    typedef kernel::MaternFiveHalves<Params> KF_t;
     typedef mean::Constant<Params> Mean_t;
     typedef model::GP<Params, KF_t, Mean_t> GP_t;
 
@@ -219,7 +219,7 @@ BOOST_AUTO_TEST_CASE(test_gp_blacklist)
 {
     using namespace limbo;
 
-    typedef kernel::MaternFiveHalfs<Params> KF_t;
+    typedef kernel::MaternFiveHalves<Params> KF_t;
     typedef mean::Constant<Params> Mean_t;
     typedef model::GP<Params, KF_t, Mean_t> GP_t;
 
@@ -300,8 +300,8 @@ BOOST_AUTO_TEST_CASE(test_gp_init_variance)
         };
     };
 
-    // MaternThreeHalfs
-    typedef model::GP<Params, kernel::MaternThreeHalfs<Parameters>, mean::Constant<Params>> GP1_t;
+    // MaternThreeHalves
+    typedef model::GP<Params, kernel::MaternThreeHalves<Parameters>, mean::Constant<Params>> GP1_t;
 
     GP1_t gp1(1, 1);
 
@@ -309,8 +309,8 @@ BOOST_AUTO_TEST_CASE(test_gp_init_variance)
 
     BOOST_CHECK_CLOSE(sigma, 10.0, 1e-5);
 
-    // MaternFiveHalfs
-    typedef model::GP<Params, kernel::MaternFiveHalfs<Parameters>, mean::Constant<Params>> GP2_t;
+    // MaternFiveHalves
+    typedef model::GP<Params, kernel::MaternFiveHalves<Parameters>, mean::Constant<Params>> GP2_t;
 
     GP2_t gp2(1, 1);
 


### PR DESCRIPTION
Hi, 
As pointed out by JBM, there were some typos in the names of the function used in the benchmark. 

This PR removes theses typos (or at least those that I saw).