### PR TITLE
finish the waf script for printing default params

### DIFF
--- a/waf_tools/limbo.py
+++ b/waf_tools/limbo.py
@@ -239,6 +239,6 @@ def output_params(folder):
         output += params.get_output(folder + '/' + file)
         output += '=========================================\n'
 
-    text_file = open("params_"+folder[4:]+".txt", "w")
+    text_file = open(folder + "/params_" + folder[4:] + ".txt", "w")
     text_file.write(output)
     text_file.close()

--- a/waf_tools/limbo.py
+++ b/waf_tools/limbo.py
@@ -242,3 +242,9 @@ def output_params(folder):
     text_file = open(folder + "/params_" + folder[4:] + ".txt", "w")
     text_file.write(output)
     text_file.close()
+
+def write_default_params(fname):
+    output = params.get_default_params()
+    text_file = open(fname, "w")
+    text_file.write(output)
+    text_file.close()

--- a/waf_tools/limbo.py
+++ b/waf_tools/limbo.py
@@ -100,6 +100,8 @@ def _sub_script(tpl, conf_file):
                 except:
                     print "WARNING, dir:" + directory + " not be created"
                 subprocess.call('cp ' + bin_dir + '/' + e + ' ' + directory, shell=True)
+                src_dir = bin_dir.replace('build/',  '')
+                subprocess.call('cp ' + src_dir + '/params_*.txt '  + directory, shell=True)
                 fname = directory + "/" + e + "_" + str(i) + ".job"
                 f = open(fname, "w")
                 f.write(tpl
@@ -162,6 +164,8 @@ def _sub_script_local(conf_file):
                 except:
                     print "WARNING, dir:" + directory + " not be created"
                 subprocess.call('cp ' + bin_dir + '/' + e + ' ' + '"' + directory + '"', shell=True)
+                src_dir = bin_dir.replace('build/',  '')
+                subprocess.call('cp ' + src_dir + '/params_*.txt '  + directory, shell=True)
                 fname = e
                 fnames += [(fname, directory)]
     return fnames,args

--- a/wscript
+++ b/wscript
@@ -27,6 +27,7 @@ def options(opt):
         opt.load('openmp')
         opt.load('nlopt')
         opt.load('libcmaes')
+        opt.load('xcode')
 
         opt.add_option('--exp', type='string', help='exp(s) to build, separate by comma', dest='exp')
         opt.add_option('--qsub', type='string', help='config file (json) to submit to torque', dest='qsub')
@@ -35,9 +36,9 @@ def options(opt):
         opt.add_option('--local_serial', type='string', help='config file (json) to run local', dest='local_serial')
         opt.add_option('--experimental', action='store_true', help='specify to compile the experimental examples', dest='experimental')
         opt.add_option('--nb_replicates', type='int', help='number of replicates performed during the benchmark', dest='nb_rep')
-        # tests
         opt.add_option('--tests', action='store_true', help='compile tests or not', dest='tests')
-        opt.load('xcode')
+        opt.add_option('--write_params', type='string', help='write all the default values of parameters in a file (used by the documentation system)', dest='write_params')
+
         for i in glob.glob('exp/*'):
                 if os.path.isdir(i):
                     opt.recurse(i)
@@ -92,6 +93,9 @@ def configure(conf):
         conf.recurse('src/benchmarks')
 
 def build(bld):
+    if bld.options.write_params:
+        limbo.write_default_params(bld.options.write_params)
+        print 'default parameters written in ' + bld.options.write_params
     bld.recurse('src/')
     if bld.options.exp:
         for i in bld.options.exp.split(','):


### PR DESCRIPTION
- now the actual parameters of an experiments are written in the experiment file
- ./waf --write_params=filename will write the limbo default params in a markdown file called 'filename'
- copy the parameters when submitting an experiment to a cluster (e.g. --oar), so that we can know what we have run