### PR TITLE
HP Opt remove assertion

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -39,7 +39,7 @@ Why am I getting "'NoLFOpt' should never be called!" assertion failure?
 
 Most probably, you are using the `BOptimizer` class and you have set an `hp_period` (rate at which the hyperparams are optimized) bigger than 0, but you are using a Gaussian Process model with no hyperparameters optimization. This should never happen. So, if you do not want to optimize any hyperparameters, set `hp_period` parameter to -1. On the other hand, if you want use a Gaussian Process model that does optimize the hyperparameters, check :ref:`here <gp-hpopt>` for available hyperparameters optimization options.
 
-Why am I getting "'XXXLFOpt' was never called!" assertion failure at the end of my program execution?
+Why am I getting "'XXXLFOpt' was never called!" errors?
 -------------------------------------------------------------------------------------------------------
 
 Most probably, you are using the `BOptimizer` class and you have set an `hp_period` (rate at which the hyperparams are optimized) less than 1, but you are using a Gaussian Process model that optimizes the hyperparameters. This should never happen. If you want use a Gaussian Process model that does optimize the hyperparameters, set the `hp_period` parameter to a value bigger than 0. On the other hand, if you do not want to optimize any hyperparameters, set `hp_period` parameter to -1 and use a Gaussian Process model that does not optimize the hyperparameters. Check :ref:`here <gp-hpopt>` for available hyperparameters optimization options.

--- a/src/limbo/model/gp/hp_opt.hpp
+++ b/src/limbo/model/gp/hp_opt.hpp
@@ -19,7 +19,6 @@ namespace limbo {
                 {
                     if (!_called) {
                         std::cerr << "'HPOpt' was never called!" << std::endl;
-                        assert(false);
                     }
                 }
 


### PR DESCRIPTION
We should remove the assertion because if we use the `BOptimizer` class and the GP with learning the hyperparameters and no initialization function, then it gets triggered. This happens because the compiler calls the descructor of the GP at this [line](https://github.com/resibots/limbo/blob/42d9ccac68017edcdff289179474db7c9d62c4c3/src/limbo/bayes_opt/boptimizer.hpp#L147).

