### PR TITLE
Enable acquisition function optimization with gradients

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -114,7 +114,7 @@ Template
       size_t dim_in() const { return _model.dim_in(); }
       size_t dim_out() const { return _model.dim_out(); }
       template <typename AggregatorFunction>
-      double operator()(const Eigen::VectorXd& v, const AggregatorFunction& afun) const
+      limbo::opt::eval_t operator()(const Eigen::VectorXd& v, const AggregatorFunction& afun, bool gradient) const
       {
         // code
       }

--- a/src/examples/obs_multi_auto_mean.cpp
+++ b/src/examples/obs_multi_auto_mean.cpp
@@ -105,8 +105,9 @@ public:
     size_t dim_out() const { return _model.dim_out(); }
 
     template <typename AggregatorFunction>
-    limbo::opt::eval_t operator()(const Eigen::VectorXd& v, const AggregatorFunction& afun) const
+    limbo::opt::eval_t operator()(const Eigen::VectorXd& v, const AggregatorFunction& afun, bool gradient) const
     {
+        assert(!gradient);
         // double mu, sigma;
         // std::tie(mu, sigma) = _model.query(v);
         // return (mu + Params::ucb::alpha() * sqrt(sigma));

--- a/src/examples/obs_multi_auto_mean.cpp
+++ b/src/examples/obs_multi_auto_mean.cpp
@@ -105,13 +105,13 @@ public:
     size_t dim_out() const { return _model.dim_out(); }
 
     template <typename AggregatorFunction>
-    double operator()(const Eigen::VectorXd& v, const AggregatorFunction& afun) const
+    limbo::opt::eval_t operator()(const Eigen::VectorXd& v, const AggregatorFunction& afun) const
     {
         // double mu, sigma;
         // std::tie(mu, sigma) = _model.query(v);
         // return (mu + Params::ucb::alpha() * sqrt(sigma));
 
-        return (sqrt(_model.sigma(v)));
+        return limbo::opt::no_grad(std::sqrt(_model.sigma(v)));
     }
 
 protected:

--- a/src/limbo/acqui/ei.hpp
+++ b/src/limbo/acqui/ei.hpp
@@ -81,8 +81,9 @@ namespace limbo {
             size_t dim_out() const { return _model.dim_out(); }
 
             template <typename AggregatorFunction>
-            opt::eval_t operator()(const Eigen::VectorXd& v, const AggregatorFunction& afun) const
+            opt::eval_t operator()(const Eigen::VectorXd& v, const AggregatorFunction& afun, bool gradient) const
             {
+                assert(!gradient);
                 Eigen::VectorXd mu;
                 double sigma_sq;
                 std::tie(mu, sigma_sq) = _model.query(v);

--- a/src/limbo/acqui/ei.hpp
+++ b/src/limbo/acqui/ei.hpp
@@ -50,6 +50,7 @@
 #include <Eigen/Core>
 
 #include <limbo/tools/macros.hpp>
+#include <limbo/opt/optimizer.hpp>
 
 namespace limbo {
     namespace defaults {
@@ -80,7 +81,7 @@ namespace limbo {
             size_t dim_out() const { return _model.dim_out(); }
 
             template <typename AggregatorFunction>
-            double operator()(const Eigen::VectorXd& v, const AggregatorFunction& afun) const
+            opt::eval_t operator()(const Eigen::VectorXd& v, const AggregatorFunction& afun) const
             {
                 Eigen::VectorXd mu;
                 double sigma_sq;
@@ -89,7 +90,7 @@ namespace limbo {
 
                 // If \sigma(x) = 0 or we do not have any observation yet we return 0
                 if (sigma < 1e-10 || _model.samples().size() < 1)
-                    return 0.0;
+                    return opt::no_grad(0.0);
 
                 // Compute EI(x)
                 // First find the best so far (predicted) observation
@@ -104,7 +105,7 @@ namespace limbo {
                 double phi = std::exp(-0.5 * std::pow(Z, 2.0)) / std::sqrt(2.0 * M_PI);
                 double Phi = 0.5 * std::erfc(-Z / std::sqrt(2)); //0.5 * (1.0 + std::erf(Z / std::sqrt(2)));
 
-                return X * Phi + sigma * phi;
+                return opt::no_grad(X * Phi + sigma * phi);
             }
 
         protected:

--- a/src/limbo/acqui/gp_ucb.hpp
+++ b/src/limbo/acqui/gp_ucb.hpp
@@ -92,8 +92,9 @@ namespace limbo {
             size_t dim_out() const { return _model.dim_out(); }
 
             template <typename AggregatorFunction>
-            opt::eval_t operator()(const Eigen::VectorXd& v, const AggregatorFunction& afun) const
+            opt::eval_t operator()(const Eigen::VectorXd& v, const AggregatorFunction& afun, bool gradient) const
             {
+                assert(!gradient);
                 Eigen::VectorXd mu;
                 double sigma;
                 std::tie(mu, sigma) = _model.query(v);

--- a/src/limbo/acqui/gp_ucb.hpp
+++ b/src/limbo/acqui/gp_ucb.hpp
@@ -48,6 +48,7 @@
 #include <Eigen/Core>
 
 #include <limbo/tools/macros.hpp>
+#include <limbo/opt/optimizer.hpp>
 
 namespace limbo {
     namespace defaults {
@@ -91,12 +92,12 @@ namespace limbo {
             size_t dim_out() const { return _model.dim_out(); }
 
             template <typename AggregatorFunction>
-            double operator()(const Eigen::VectorXd& v, const AggregatorFunction& afun) const
+            opt::eval_t operator()(const Eigen::VectorXd& v, const AggregatorFunction& afun) const
             {
                 Eigen::VectorXd mu;
                 double sigma;
                 std::tie(mu, sigma) = _model.query(v);
-                return (afun(mu) + _beta * std::sqrt(sigma));
+                return opt::no_grad(afun(mu) + _beta * std::sqrt(sigma));
             }
 
         protected:

--- a/src/limbo/acqui/ucb.hpp
+++ b/src/limbo/acqui/ucb.hpp
@@ -79,8 +79,9 @@ namespace limbo {
             size_t dim_out() const { return _model.dim_out(); }
 
             template <typename AggregatorFunction>
-            opt::eval_t operator()(const Eigen::VectorXd& v, const AggregatorFunction& afun) const
+            opt::eval_t operator()(const Eigen::VectorXd& v, const AggregatorFunction& afun, bool gradient) const
             {
+                assert(!gradient);
                 Eigen::VectorXd mu;
                 double sigma;
                 std::tie(mu, sigma) = _model.query(v);

--- a/src/limbo/acqui/ucb.hpp
+++ b/src/limbo/acqui/ucb.hpp
@@ -48,6 +48,7 @@
 #include <Eigen/Core>
 
 #include <limbo/tools/macros.hpp>
+#include <limbo/opt/optimizer.hpp>
 
 namespace limbo {
     namespace defaults {
@@ -78,12 +79,12 @@ namespace limbo {
             size_t dim_out() const { return _model.dim_out(); }
 
             template <typename AggregatorFunction>
-            double operator()(const Eigen::VectorXd& v, const AggregatorFunction& afun) const
+            opt::eval_t operator()(const Eigen::VectorXd& v, const AggregatorFunction& afun) const
             {
                 Eigen::VectorXd mu;
                 double sigma;
                 std::tie(mu, sigma) = _model.query(v);
-                return (afun(mu) + Params::acqui_ucb::alpha() * sqrt(sigma));
+                return opt::no_grad(afun(mu) + Params::acqui_ucb::alpha() * sqrt(sigma));
             }
 
         protected:

--- a/src/limbo/bayes_opt/boptimizer.hpp
+++ b/src/limbo/bayes_opt/boptimizer.hpp
@@ -152,7 +152,7 @@ namespace limbo {
                     acquisition_function_t acqui(_model, this->_current_iteration);
 
                     auto acqui_optimization =
-                        [&](const Eigen::VectorXd& x, bool g) { return acqui(x,afun); };
+                        [&](const Eigen::VectorXd& x, bool g) { return acqui(x,afun,g); };
                     Eigen::VectorXd starting_point = tools::random_vector(StateFunction::dim_in);
                     Eigen::VectorXd new_sample = acqui_optimizer(acqui_optimization, starting_point, true);
                     bool blacklisted = !this->eval_and_add(sfun, new_sample);

--- a/src/limbo/bayes_opt/boptimizer.hpp
+++ b/src/limbo/bayes_opt/boptimizer.hpp
@@ -87,23 +87,23 @@ namespace limbo {
         /**
         The classic Bayesian optimization algorithm.
 
-        \\rst
+        \rst
         References: :cite:`brochu2010tutorial,Mockus2013`
-        \\endrst
+        \endrst
 
         This class takes the same template parameters as BoBase. It adds:
-        \\rst
+        \rst
         +---------------------+------------+----------+---------------+
         |type                 |typedef     | argument | default       |
         +=====================+============+==========+===============+
         |acqui. optimizer     |acqui_opt_t | acquiopt | see below     |
         +---------------------+------------+----------+---------------+
-        \\endrst
+        \endrst
 
         The default value of acqui_opt_t is:
-        - ``opt::Cmaes<Params>`` if libcmaes was found in `waf configure`
-        - ``opt::NLOptNoGrad<Params, nlopt::GN_DIRECT_L_RAND>`` if NLOpt was found but libcmaes was not found
-        - ``opt::GridSearch<Params>`` otherwise (please do not use this: the algorithm will not work at all!)
+        - ``opt::NLOptNoGrad<Params, nlopt::GN_DIRECT_L_RAND>`` if NLOpt was found in `waf configure`
+        - ``opt::Cmaes<Params>`` if libcmaes was found but NLOpt was not found
+        - ``opt::GridSearch<Params>`` otherwise (please do not use this: the algorithm will not work as expected!)
         */
         template <class Params,
           class A1 = boost::parameter::void_,

--- a/src/limbo/bayes_opt/boptimizer.hpp
+++ b/src/limbo/bayes_opt/boptimizer.hpp
@@ -151,9 +151,8 @@ namespace limbo {
                 while (!this->_stop(*this, afun)) {
                     acquisition_function_t acqui(_model, this->_current_iteration);
 
-                    // we do not have gradient in our current acquisition function
                     auto acqui_optimization =
-                        [&](const Eigen::VectorXd& x, bool g) { return opt::no_grad(acqui(x, afun)); };
+                        [&](const Eigen::VectorXd& x, bool g) { return acqui(x,afun); };
                     Eigen::VectorXd starting_point = tools::random_vector(StateFunction::dim_in);
                     Eigen::VectorXd new_sample = acqui_optimizer(acqui_optimization, starting_point, true);
                     bool blacklisted = !this->eval_and_add(sfun, new_sample);

--- a/src/limbo/stat/gp.hpp
+++ b/src/limbo/stat/gp.hpp
@@ -80,7 +80,7 @@ namespace limbo {
                     point[dim_in] = x;
                     if (dim_in == current.size() - 1) {
                         auto q = bo.model().query(point);
-                        double acqui = typename BO::acquisition_function_t(bo.model(), bo.current_iteration())(point, afun);
+                        double acqui = std::get<0>(typename BO::acquisition_function_t(bo.model(), bo.current_iteration())(point, afun));
                         ofs << point.transpose() << " "
                             << std::get<0>(q).transpose() << " "
                             << std::get<1>(q) << " "

--- a/src/limbo/stat/gp.hpp
+++ b/src/limbo/stat/gp.hpp
@@ -80,7 +80,7 @@ namespace limbo {
                     point[dim_in] = x;
                     if (dim_in == current.size() - 1) {
                         auto q = bo.model().query(point);
-                        double acqui = std::get<0>(typename BO::acquisition_function_t(bo.model(), bo.current_iteration())(point, afun));
+                        double acqui = std::get<0>(typename BO::acquisition_function_t(bo.model(), bo.current_iteration())(point, afun, false));
                         ofs << point.transpose() << " "
                             << std::get<0>(q).transpose() << " "
                             << std::get<1>(q) << " "

--- a/src/limbo/stat/gp.hpp
+++ b/src/limbo/stat/gp.hpp
@@ -80,7 +80,7 @@ namespace limbo {
                     point[dim_in] = x;
                     if (dim_in == current.size() - 1) {
                         auto q = bo.model().query(point);
-                        double acqui = std::get<0>(typename BO::acquisition_function_t(bo.model(), bo.current_iteration())(point, afun, false));
+                        double acqui = opt::fun(typename BO::acquisition_function_t(bo.model(), bo.current_iteration())(point, afun, false));
                         ofs << point.transpose() << " "
                             << std::get<0>(q).transpose() << " "
                             << std::get<1>(q) << " "

--- a/src/limbo/stat/gp_acquisitions.hpp
+++ b/src/limbo/stat/gp_acquisitions.hpp
@@ -71,11 +71,11 @@ namespace limbo {
 
                 if (!blacklisted && !bo.samples().empty()) {
                     std::tie(mu, sigma) = bo.model().query(bo.samples().back());
-                    acqui = std::get<0>(typename BO::acquisition_function_t(bo.model(), bo.current_iteration())(bo.samples().back(), afun, false));
+                    acqui = opt::fun(typename BO::acquisition_function_t(bo.model(), bo.current_iteration())(bo.samples().back(), afun, false));
                 }
                 else if (!bo.bl_samples().empty()) {
                     std::tie(mu, sigma) = bo.model().query(bo.bl_samples().back());
-                    acqui = std::get<0>(typename BO::acquisition_function_t(bo.model(), bo.current_iteration())(bo.bl_samples().back(), afun, false));
+                    acqui = opt::fun(typename BO::acquisition_function_t(bo.model(), bo.current_iteration())(bo.bl_samples().back(), afun, false));
                 }
                 else
                     return;

--- a/src/limbo/stat/gp_acquisitions.hpp
+++ b/src/limbo/stat/gp_acquisitions.hpp
@@ -71,11 +71,11 @@ namespace limbo {
 
                 if (!blacklisted && !bo.samples().empty()) {
                     std::tie(mu, sigma) = bo.model().query(bo.samples().back());
-                    acqui = typename BO::acquisition_function_t(bo.model(), bo.current_iteration())(bo.samples().back(), afun);
+                    acqui = std::get<0>(typename BO::acquisition_function_t(bo.model(), bo.current_iteration())(bo.samples().back(), afun));
                 }
                 else if (!bo.bl_samples().empty()) {
                     std::tie(mu, sigma) = bo.model().query(bo.bl_samples().back());
-                    acqui = typename BO::acquisition_function_t(bo.model(), bo.current_iteration())(bo.bl_samples().back(), afun);
+                    acqui = std::get<0>(typename BO::acquisition_function_t(bo.model(), bo.current_iteration())(bo.bl_samples().back(), afun));
                 }
                 else
                     return;

--- a/src/limbo/stat/gp_acquisitions.hpp
+++ b/src/limbo/stat/gp_acquisitions.hpp
@@ -71,11 +71,11 @@ namespace limbo {
 
                 if (!blacklisted && !bo.samples().empty()) {
                     std::tie(mu, sigma) = bo.model().query(bo.samples().back());
-                    acqui = std::get<0>(typename BO::acquisition_function_t(bo.model(), bo.current_iteration())(bo.samples().back(), afun));
+                    acqui = std::get<0>(typename BO::acquisition_function_t(bo.model(), bo.current_iteration())(bo.samples().back(), afun, false));
                 }
                 else if (!bo.bl_samples().empty()) {
                     std::tie(mu, sigma) = bo.model().query(bo.bl_samples().back());
-                    acqui = std::get<0>(typename BO::acquisition_function_t(bo.model(), bo.current_iteration())(bo.bl_samples().back(), afun));
+                    acqui = std::get<0>(typename BO::acquisition_function_t(bo.model(), bo.current_iteration())(bo.bl_samples().back(), afun, false));
                 }
                 else
                     return;

--- a/src/tests/test_gp.cpp
+++ b/src/tests/test_gp.cpp
@@ -252,7 +252,7 @@ BOOST_AUTO_TEST_CASE(test_gp_no_samples_acqui_opt)
 
     // we do not have gradient in our current acquisition function
     auto acqui_optimization =
-        [&](const Eigen::VectorXd& x, bool g) { return acqui(x, FirstElem()); };
+        [&](const Eigen::VectorXd& x, bool g) { return acqui(x, FirstElem(), g); };
     Eigen::VectorXd starting_point = tools::random_vector(2);
     Eigen::VectorXd test = acqui_optimizer(acqui_optimization, starting_point, true);
     BOOST_CHECK(test(0) < 1e-5);

--- a/src/tests/test_gp.cpp
+++ b/src/tests/test_gp.cpp
@@ -252,7 +252,7 @@ BOOST_AUTO_TEST_CASE(test_gp_no_samples_acqui_opt)
 
     // we do not have gradient in our current acquisition function
     auto acqui_optimization =
-        [&](const Eigen::VectorXd& x, bool g) { return opt::no_grad(acqui(x, FirstElem())); };
+        [&](const Eigen::VectorXd& x, bool g) { return acqui(x, FirstElem()); };
     Eigen::VectorXd starting_point = tools::random_vector(2);
     Eigen::VectorXd test = acqui_optimizer(acqui_optimization, starting_point, true);
     BOOST_CHECK(test(0) < 1e-5);


### PR DESCRIPTION
Enable acquisition function optimization with gradients. Minor changes in the API:

- The acquisition functions should return the `opt::eval_t` type and not `double`
- The acquisition functions expect one more parameter: a boolean value whether they should return the gradient or not.

I am preparing a small example (I will also maybe add it in the docs) for showcase.

Let me know what you think...

