### PR TITLE
GP fixes

### DIFF
--- a/docs/tutorials/gp.rst
+++ b/docs/tutorials/gp.rst
@@ -80,12 +80,12 @@ It uses the default values for the parameters of ``SquaredExpARD``:
    :linenos:
    :lines: 63-64
 
-After calling the ``compute()`` method, the hyper-parameters can be optimized by calling the 'optimize_hyperparams()' function. Once the new parameters are found, the GP needs to be recomputed:
+After calling the ``compute()`` method, the hyper-parameters can be optimized by calling the ``optimize_hyperparams()`` function. The GP does not need to be recomputed:
 
 .. literalinclude:: ../../src/tutorials/gp.cpp
    :language: c++
    :linenos:
-   :lines: 121-123
+   :lines: 121-122
 
 
 We can have a look at the difference between the two GPs:

--- a/src/limbo/model/gp.hpp
+++ b/src/limbo/model/gp.hpp
@@ -77,7 +77,7 @@ namespace limbo {
             /// Compute the GP from samples, observation, noise. This call needs to be explicit!
             void compute(const std::vector<Eigen::VectorXd>& samples,
                 const std::vector<Eigen::VectorXd>& observations,
-                const Eigen::VectorXd& noises)
+                const Eigen::VectorXd& noises, bool compute_kernel = true)
             {
                 assert(samples.size() != 0);
                 assert(observations.size() != 0);
@@ -100,7 +100,8 @@ namespace limbo {
                 _noises = noises;
 
                 this->_compute_obs_mean();
-                this->_compute_full_kernel();
+                if (compute_kernel)
+                    this->_compute_full_kernel();
             }
 
             /// Do not forget to call this if you use hyper-prameters optimization!!

--- a/src/tutorials/gp.cpp
+++ b/src/tutorials/gp.cpp
@@ -120,7 +120,6 @@ int main(int argc, char** argv)
     // do not forget to call the optimization!
     gp_ard.compute(samples, observations, noises);
     gp_ard.optimize_hyperparams();
-    gp_ard.recompute(false);
 
     // write the predicted data in a file (e.g. to be plotted)
     std::ofstream ofs_ard("gp_ard.dat");

--- a/src/tutorials/gp.cpp
+++ b/src/tutorials/gp.cpp
@@ -118,7 +118,7 @@ int main(int argc, char** argv)
 
     GP2_t gp_ard(1, 1);
     // do not forget to call the optimization!
-    gp_ard.compute(samples, observations, noises);
+    gp_ard.compute(samples, observations, noises, false);
     gp_ard.optimize_hyperparams();
 
     // write the predicted data in a file (e.g. to be plotted)


### PR DESCRIPTION
As discussed internally, we should be able to give to the user a GP interface that avoids extra meaningless computations. One of them is the following: *if I want to use just GPs and optimize the hyperparameters,* **there's no need to compute the full kernel before**. At the moment, there's no such functionality in limbo. That's what I am adding with this PR: call ``compute()``, but also be able to not do the kernel calculation which will be redone in the hyperparams optimization.
