### PR TITLE
Avoiding to reconstruct the mean object when it's not necessary.

### DIFF
--- a/src/limbo/model/gp.hpp
+++ b/src/limbo/model/gp.hpp
@@ -86,8 +86,10 @@ namespace limbo {
                 _dim_in = samples[0].size();
                 _kernel_function = KernelFunction(_dim_in); // the cost of building a functor should be relatively low
 
-                _dim_out = observations[0].size();
-                _mean_function = MeanFunction(_dim_out); // the cost of building a functor should be relatively low
+                if (_dim_out != observations[0].size()) {
+                    _dim_out = observations[0].size();
+                    _mean_function = MeanFunction(_dim_out); // the cost of building a functor should be relatively low
+                }
 
                 _samples = samples;
 

--- a/src/limbo/model/gp.hpp
+++ b/src/limbo/model/gp.hpp
@@ -83,10 +83,10 @@ namespace limbo {
                 assert(observations.size() != 0);
                 assert(samples.size() == observations.size());
 
-		if (_dim_in != samples[0].size()) {
-		    _dim_in = samples[0].size();
-		    _kernel_function = KernelFunction(_dim_in); // the cost of building a functor should be relatively low
-		}
+                if (_dim_in != samples[0].size()) {
+                    _dim_in = samples[0].size();
+                    _kernel_function = KernelFunction(_dim_in); // the cost of building a functor should be relatively low
+                }
 
                 if (_dim_out != observations[0].size()) {
                     _dim_out = observations[0].size();
@@ -119,14 +119,14 @@ namespace limbo {
             void add_sample(const Eigen::VectorXd& sample, const Eigen::VectorXd& observation, double noise)
             {
                 if (_samples.empty()) {
-		  if (_dim_in != sample.size()) {
-                    _dim_in = sample.size();
-                    _kernel_function = KernelFunction(_dim_in); // the cost of building a functor should be relatively low
-		  }
-		  if (_dim_out != observation.size()) {
-		    _dim_out = observation.size();
-		    _mean_function = MeanFunction(_dim_out); // the cost of building a functor should be relatively low
-		  }
+                    if (_dim_in != sample.size()) {
+                        _dim_in = sample.size();
+                        _kernel_function = KernelFunction(_dim_in); // the cost of building a functor should be relatively low
+                    }
+                    if (_dim_out != observation.size()) {
+                        _dim_out = observation.size();
+                        _mean_function = MeanFunction(_dim_out); // the cost of building a functor should be relatively low
+                    }
                 }
                 else {
                     assert(sample.size() == _dim_in);

--- a/src/limbo/model/gp.hpp
+++ b/src/limbo/model/gp.hpp
@@ -83,8 +83,10 @@ namespace limbo {
                 assert(observations.size() != 0);
                 assert(samples.size() == observations.size());
 
-                _dim_in = samples[0].size();
-                _kernel_function = KernelFunction(_dim_in); // the cost of building a functor should be relatively low
+		if (_dim_in != samples[0].size()) {
+		    _dim_in = samples[0].size();
+		    _kernel_function = KernelFunction(_dim_in); // the cost of building a functor should be relatively low
+		}
 
                 if (_dim_out != observations[0].size()) {
                     _dim_out = observations[0].size();
@@ -117,11 +119,14 @@ namespace limbo {
             void add_sample(const Eigen::VectorXd& sample, const Eigen::VectorXd& observation, double noise)
             {
                 if (_samples.empty()) {
+		  if (_dim_in != sample.size()) {
                     _dim_in = sample.size();
                     _kernel_function = KernelFunction(_dim_in); // the cost of building a functor should be relatively low
-
-                    _dim_out = observation.size();
-                    _mean_function = MeanFunction(_dim_out); // the cost of building a functor should be relatively low
+		  }
+		  if (_dim_out != observation.size()) {
+		    _dim_out = observation.size();
+		    _mean_function = MeanFunction(_dim_out); // the cost of building a functor should be relatively low
+		  }
                 }
                 else {
                     assert(sample.size() == _dim_in);


### PR DESCRIPTION
Hi all,

A small change that prevent the GP to reconstruct the Mean Object as long as there is not difference in dim_out. 
While it's a minor performance improvement, it also allows to have more advance mean object that can store data over the time.

If the CI passes, it's ready to merge.