### PR TITLE
avoid to recompute the kernel when not needed in MeanLF

### DIFF
--- a/src/limbo/model/gp.hpp
+++ b/src/limbo/model/gp.hpp
@@ -228,22 +228,17 @@ namespace limbo {
             int nb_samples() const { return _samples.size(); }
 
             ///  recomputes the GP
-            void recompute(bool update_obs_mean = true)
+            void recompute(bool update_obs_mean = true, bool update_full_kernel = true)
             {
                 assert(!_samples.empty());
 
                 if (update_obs_mean)
                     this->_compute_obs_mean();
 
-                this->_compute_full_kernel();
-            }
-
-            /// recomputes the internal variable related to the mean object without recomputing the kernel
-            void recompute_mean_internal()
-            {
-                assert(!_samples.empty());
-                this->_compute_obs_mean();
-                this->_compute_alpha();
+                if (update_full_kernel)
+                    this->_compute_full_kernel();
+                else
+                    this->_compute_alpha();
             }
 
             /// return the likelihood (do not compute it!)

--- a/src/limbo/model/gp.hpp
+++ b/src/limbo/model/gp.hpp
@@ -238,6 +238,14 @@ namespace limbo {
                 this->_compute_full_kernel();
             }
 
+            /// recomputes the internal variable related to the mean object without recomputing the kernel
+            void recompute_mean_internal()
+            {
+                assert(!_samples.empty());
+                this->_compute_obs_mean();
+                this->_compute_alpha();
+            }
+
             /// return the likelihood (do not compute it!)
             double get_lik() const { return _lik; }
 

--- a/src/limbo/model/gp/mean_lf_opt.hpp
+++ b/src/limbo/model/gp/mean_lf_opt.hpp
@@ -65,7 +65,7 @@ namespace limbo {
                     auto params = optimizer(optimization, gp.mean_function().h_params(), false);
                     gp.mean_function().set_h_params(params);
                     gp.set_lik(opt::eval(optimization, params));
-                    gp.recompute_mean_internal();
+                    gp.recompute(true, false);
                 }
 
             protected:
@@ -87,7 +87,7 @@ namespace limbo {
                         GP gp(this->_original_gp);
                         gp.mean_function().set_h_params(params);
 
-                        gp.recompute_mean_internal();
+                        gp.recompute(true, false);
 
                         size_t n = gp.obs_mean().rows();
 

--- a/src/limbo/model/gp/mean_lf_opt.hpp
+++ b/src/limbo/model/gp/mean_lf_opt.hpp
@@ -65,21 +65,29 @@ namespace limbo {
                     auto params = optimizer(optimization, gp.mean_function().h_params(), false);
                     gp.mean_function().set_h_params(params);
                     gp.set_lik(opt::eval(optimization, params));
-                    gp.recompute(true);
+                    gp.recompute_mean_internal();
                 }
 
             protected:
                 template <typename GP>
                 struct MeanLFOptimization {
                 public:
-                    MeanLFOptimization(const GP& gp) : _original_gp(gp) {}
+                    MeanLFOptimization(const GP& gp) : _original_gp(gp)
+                    {
+                        size_t n = gp.obs_mean().rows();
+
+                        // K^{-1} using Cholesky decomposition
+                        _K = Eigen::MatrixXd::Identity(n, n);
+                        gp.matrixL().template triangularView<Eigen::Lower>().solveInPlace(_K);
+                        gp.matrixL().template triangularView<Eigen::Lower>().transpose().solveInPlace(_K);
+                    }
 
                     opt::eval_t operator()(const Eigen::VectorXd& params, bool compute_grad) const
                     {
                         GP gp(this->_original_gp);
                         gp.mean_function().set_h_params(params);
 
-                        gp.recompute(true);
+                        gp.recompute_mean_internal();
 
                         size_t n = gp.obs_mean().rows();
 
@@ -97,15 +105,10 @@ namespace limbo {
                         if (!compute_grad)
                             return opt::no_grad(lik);
 
-                        // K^{-1} using Cholesky decomposition
-                        Eigen::MatrixXd K = Eigen::MatrixXd::Identity(n, n);
-                        gp.matrixL().template triangularView<Eigen::Lower>().solveInPlace(K);
-                        gp.matrixL().template triangularView<Eigen::Lower>().transpose().solveInPlace(K);
-
                         Eigen::VectorXd grad = Eigen::VectorXd::Zero(params.size());
                         for (int i_obs = 0; i_obs < gp.dim_out(); ++i_obs)
                             for (size_t n_obs = 0; n_obs < n; n_obs++) {
-                                grad.tail(gp.mean_function().h_params_size()) += gp.obs_mean().col(i_obs).transpose() * K.col(n_obs) * gp.mean_function().grad(gp.samples()[n_obs], gp).row(i_obs);
+                                grad.tail(gp.mean_function().h_params_size()) += gp.obs_mean().col(i_obs).transpose() * _K.col(n_obs) * gp.mean_function().grad(gp.samples()[n_obs], gp).row(i_obs);
                             }
 
                         return {lik, grad};
@@ -113,6 +116,7 @@ namespace limbo {
 
                 protected:
                     const GP& _original_gp;
+                    Eigen::MatrixXd _K;
                 };
             };
         }


### PR DESCRIPTION
Hi all, 

I realized that the Mean_lf_opt object actually recomputes the kernel at each iteration of the HP optimization, while it's useless (this object is supposed to only change the HP associated to the mean). I removed all the unnecessary computation and I needed a new public method to recompute "_obs_mean" and "_alpha" (feel free to change the name if you do not like it). 