### PR TITLE
Fix minor typos

### DIFF
--- a/docs/tutorials/gp.rst
+++ b/docs/tutorials/gp.rst
@@ -18,12 +18,12 @@ We assume that our samples are in a vector called ``samples`` and that our obser
 Basic usage
 ------------
 
-We first create a basic GP with an Exponential kernel (``kernel::Exp<Params>``) and a mean function equals to the mean of the obsevations (``mean::Data<Params>``). The ``Exp`` kernel needs a few parameters to be defined in a ``Params`` structure:
+We first create a basic GP with an Exponential kernel (``kernel::Exp<Params>``) and a mean function equals to the mean of the observations (``mean::Data<Params>``). The ``Exp`` kernel needs a few parameters to be defined in a ``Params`` structure:
 
 .. literalinclude:: ../../src/tutorials/gp.cpp
    :language: c++
    :linenos:
-   :lines: 60-63
+   :lines: 59-70
 
 The type of the GP is defined by the following lines:
 
@@ -99,4 +99,10 @@ This plot is generated using matplotlib:
 
 .. literalinclude:: ../../src/tutorials/plot_gp.py
    :language: python
+   :linenos:
+
+Here is the complete ``main.cpp`` file of this tutorial:
+
+.. literalinclude:: ../../src/tutorials/gp.cpp
+   :language: c++
    :linenos:

--- a/src/limbo/bayes_opt/boptimizer.hpp
+++ b/src/limbo/bayes_opt/boptimizer.hpp
@@ -97,7 +97,7 @@ namespace limbo {
         +---------------------+------------+----------+---------------+
         |type                 |typedef     | argument | default       |
         +=====================+============+==========+===============+
-        |acqui. optimizer     |acquiopt_t | acquiopt | see below     |
+        |acqui. optimizer     |acquiopt_t  | acquiopt | see below     |
         +---------------------+------------+----------+---------------+
         \endrst
 

--- a/src/limbo/bayes_opt/boptimizer.hpp
+++ b/src/limbo/bayes_opt/boptimizer.hpp
@@ -97,7 +97,7 @@ namespace limbo {
         +---------------------+------------+----------+---------------+
         |type                 |typedef     | argument | default       |
         +=====================+============+==========+===============+
-        |acqui. optimizer     |acqui_opt_t | acquiopt | see below     |
+        |acqui. optimizer     |acquiopt_t | acquiopt | see below     |
         +---------------------+------------+----------+---------------+
         \endrst
 


### PR DESCRIPTION
One of my colleague using limbo spotted a few typos in the api documentation, and found that the complete source code at the end of the GP tutorial was missing. 

I fixed this. 