### PR TITLE
Additional parameters for CMAES

### DIFF
--- a/src/limbo/opt/cmaes.hpp
+++ b/src/limbo/opt/cmaes.hpp
@@ -111,8 +111,15 @@ namespace limbo {
         /// - Only available if libcmaes is installed (see the compilation instructions)
         ///
         /// - Parameters :
-        ///   - double max_fun_evals
         ///   - int restarts
+        ///   - double max_fun_evals
+        ///   - fun_tolerance
+        ///   - fun_target
+        ///   - fun_compute_initial
+        ///   - variant
+        ///   - elitism
+        ///   - handle_uncertainty
+        ///   - verbose
         template <typename Params>
         struct Cmaes {
         public:

--- a/src/limbo/opt/cmaes.hpp
+++ b/src/limbo/opt/cmaes.hpp
@@ -46,13 +46,13 @@
 #ifndef LIMBO_OPT_CMAES_HPP
 #define LIMBO_OPT_CMAES_HPP
 
-#include <vector>
-#include <iostream>
 #include <Eigen/Core>
+#include <iostream>
+#include <vector>
 
+#include <limbo/opt/optimizer.hpp>
 #include <limbo/tools/macros.hpp>
 #include <limbo/tools/parallel.hpp>
-#include <limbo/opt/optimizer.hpp>
 
 #ifndef USE_LIBCMAES
 #warning NO libcmaes support
@@ -119,9 +119,9 @@ namespace limbo {
 
                 // wrap the function
                 libcmaes::FitFunc f_cmaes = [&](const double* x, const int n) {
-		Eigen::Map<const Eigen::VectorXd> m(x, n);
-		// remember that our optimizers maximize
-		return -eval(f, m);
+                    Eigen::Map<const Eigen::VectorXd> m(x, n);
+                    // remember that our optimizers maximize
+                    return -eval(f, m);
                 };
 
                 if (bounded)
@@ -202,7 +202,8 @@ namespace limbo {
                     // we do not know if what is the actual maximum / minimum of the function
                     // therefore we deactivate this stopping criterion
                     cmaparams.set_stopping_criteria(FTARGET, false);
-                } else {
+                }
+                else {
                     // the FTARGET criteria also allows us to enable ftolerance
                     cmaparams.set_stopping_criteria(FTARGET, true);
                     cmaparams.set_ftolerance(Params::opt_cmaes::fun_tolerance());

--- a/src/limbo/opt/cmaes.hpp
+++ b/src/limbo/opt/cmaes.hpp
@@ -77,11 +77,17 @@ namespace limbo {
             /// sets the version of cmaes to use
             BO_PARAM(int, cmaes_variant, aIPOP_CMAES);
             /// @ingroup opt_defaults
-            /// enables or disables verbose mode for cmaes
-            BO_PARAM(bool, verbose, false);
-            /// @ingroup opt_defaults
             /// function value target
             BO_PARAM(double, fun_target, -1);
+            /// @ingroup opt_defaults
+            /// computes initial objective function value
+            BO_PARAM(bool, fun_compute_initial, false);
+            /// @ingroup opt_defaults
+            /// enables or disables uncertainty handling
+            BO_PARAM(bool, handle_uncertainty, false);
+            /// @ingroup opt_defaults
+            /// enables or disables verbose mode for cmaes
+            BO_PARAM(bool, verbose, false);
         };
     }
     namespace opt {
@@ -203,7 +209,9 @@ namespace limbo {
                 cmaparams.set_stopping_criteria(EQUALFUNVALS, true);
                 cmaparams.set_stopping_criteria(MAXFEVALS, true);
 
-                // enable verbose mode of cmaes
+                // enable or disable different parameters
+                cmaparams.set_initial_fvalue(Params::opt_cmaes::fun_compute_initial());
+                cmaparams.set_uh(Params::opt_cmaes::handle_uncertainty());
                 cmaparams.set_quiet(!Params::opt_cmaes::verbose());
             }
         };

--- a/src/limbo/opt/cmaes.hpp
+++ b/src/limbo/opt/cmaes.hpp
@@ -79,6 +79,9 @@ namespace limbo {
             /// @ingroup opt_defaults
             /// enables or disables verbose mode for cmaes
             BO_PARAM(bool, verbose, false);
+            /// @ingroup opt_defaults
+            /// function value target
+            BO_PARAM(double, fun_target, -1);
         };
     }
     namespace opt {
@@ -188,6 +191,12 @@ namespace limbo {
                   // the FTARGET criteria also allows us to enable ftolerance
                   cmaparams.set_stopping_criteria(FTARGET, true);
                   cmaparams.set_ftolerance(1);
+                }
+
+                // we allow to set the ftarget parameter
+                if (Params::opt_cmaes::fun_target() != -1) {
+                  cmaparams.set_stopping_criteria(FTARGET, true);
+                  cmaparams.set_ftarget(-Params::opt_cmaes::fun_target());
                 }
 
                 // enable stopping criteria by several equalfunvals and maxfevals

--- a/src/limbo/opt/cmaes.hpp
+++ b/src/limbo/opt/cmaes.hpp
@@ -196,7 +196,7 @@ namespace limbo {
                 } else {
                   // the FTARGET criteria also allows us to enable ftolerance
                   cmaparams.set_stopping_criteria(FTARGET, true);
-                  cmaparams.set_ftolerance(1);
+                  cmaparams.set_ftolerance(Params::opt_cmaes::fun_tolerance());
                 }
 
                 // we allow to set the ftarget parameter

--- a/src/limbo/opt/cmaes.hpp
+++ b/src/limbo/opt/cmaes.hpp
@@ -81,7 +81,7 @@ namespace limbo {
             BO_PARAM(bool, fun_compute_initial, false);
             /// @ingroup opt_defaults
             /// sets the version of cmaes to use
-            BO_PARAM(int, cmaes_variant, aIPOP_CMAES);
+            BO_PARAM(int, variant, aIPOP_CMAES);
             /// @ingroup opt_defaults
             /// defines elitism strategy:
             /// 0 -> no elitism
@@ -98,6 +98,7 @@ namespace limbo {
             BO_PARAM(bool, verbose, false);
         };
     }
+
     namespace opt {
         /// @ingroup opt
         /// Covariance Matrix Adaptation Evolution Strategy by Hansen et al.
@@ -186,7 +187,7 @@ namespace limbo {
                 // aCMAES should be the best choice
                 // [see: https://github.com/beniz/libcmaes/wiki/Practical-hints ]
                 // but we want the restart -> aIPOP_CMAES
-                cmaparams.set_algo(Params::opt_cmaes::cmaes_variant());
+                cmaparams.set_algo(Params::opt_cmaes::variant());
                 cmaparams.set_restarts(Params::opt_cmaes::restarts());
                 cmaparams.set_elitism(Params::opt_cmaes::elitism());
 

--- a/src/limbo/opt/cmaes.hpp
+++ b/src/limbo/opt/cmaes.hpp
@@ -67,17 +67,20 @@ namespace limbo {
             /// number of restarts of CMA-ES
             BO_PARAM(int, restarts, 1);
             /// @ingroup opt_defaults
-            /// number of calls to the function to be optimized
+            /// maximum number of calls to the function to be optimized
             BO_PARAM(double, max_fun_evals, -1);
             /// @ingroup opt_defaults
             /// threshold based on the difference in value of a fixed number
-            /// of trials
+            /// of trials: if different to -1, it enables the tolerance criteria
+            /// for stopping based in the history of rewards.
             BO_PARAM(double, fun_tolerance, -1);
             /// @ingroup opt_defaults
-            /// function value target
+            /// function value target: if different to -1, enables the function
+            /// target criteria for stopping if the performance is greater than this value.
             BO_PARAM(double, fun_target, -1);
             /// @ingroup opt_defaults
-            /// computes initial objective function value
+            /// computes initial objective function value: if true, it evaluates the
+            /// provided starting point (if any).
             BO_PARAM(bool, fun_compute_initial, false);
             /// @ingroup opt_defaults
             /// sets the version of cmaes to use
@@ -91,7 +94,7 @@ namespace limbo {
             /// solution and reinjects the best solution until the population has better fitness, in its majority
             BO_PARAM(int, elitism, 0);
             /// @ingroup opt_defaults
-            /// enables or disables uncertainty handling
+            /// enables or disables uncertainty handling: https://hal.inria.fr/file/index/docid/276216/filename/TEC2008.pdf
             BO_PARAM(bool, handle_uncertainty, false);
             /// @ingroup opt_defaults
             /// enables or disables verbose mode for cmaes

--- a/src/limbo/opt/cmaes.hpp
+++ b/src/limbo/opt/cmaes.hpp
@@ -111,15 +111,15 @@ namespace limbo {
         /// - Only available if libcmaes is installed (see the compilation instructions)
         ///
         /// - Parameters :
+        ///   - int variant
+        ///   - int elitism
         ///   - int restarts
         ///   - double max_fun_evals
-        ///   - fun_tolerance
-        ///   - fun_target
-        ///   - fun_compute_initial
-        ///   - variant
-        ///   - elitism
-        ///   - handle_uncertainty
-        ///   - verbose
+        ///   - double fun_tolerance
+        ///   - double fun_target
+        ///   - bool fun_compute_initial
+        ///   - bool handle_uncertainty
+        ///   - bool verbose
         template <typename Params>
         struct Cmaes {
         public:

--- a/src/tutorials/advanced_example.cpp
+++ b/src/tutorials/advanced_example.cpp
@@ -74,7 +74,7 @@ struct Params {
     };
     struct opt_parallelrepeater : public defaults::opt_parallelrepeater {
     };
-    struct opt_cmaes {
+    struct opt_cmaes : public defaults::opt_cmaes {
         BO_PARAM(int, restarts, 1);
         BO_PARAM(int, max_fun_evals, -1);
     };


### PR DESCRIPTION
Adds parameters to the CMA-ES wrapper. Using the default options leaves the previous parameters as they were used before.

Quick remark to take into account: It seems different variants of CMA-ES are using the parameters differently. For example, in the case of aIPOP_CMAES, the maximum function evaluation is global across restarts, while in aBIPOP_CMAES is local in a restart. This normally will give us a greater number of evaluations when using aBIPOP.

Some quick reference about the new parameters:
- variant: Allows to change the variant to be used during the optimization. Possible values are: CMAES_DEFAULT, IPOP_CMAES, BIPOP_CMAES, aCMAES, aIPOP_CMAES, aBIPOP_CMAES, sepCMAES, sepIPOP_CMAES, sepBIPOP_CMAES, sepaCMAES, sepaIPOP_CMAES, sepaBIPOP_CMAES, VD_CMAES, VD_IPOP_CMAES and VD_BIPOP_CMAES.
- fun_tolerance: If different to -1, it enables the tolerance criteria for stopping based in the history of rewards. It triggers when the difference between the best reward and the kth one is lower than the number set on this value.
- fun_target: If different to -1, enables the function target criteria for stopping if the obtained reward is greater than this value.
- fun_compute_initial: If true, it evaluates the provided starting point (if any).
- elitism: defines elitism strategy to use during the optimization
    0 -> no elitism
    1 -> elitism: reinjects the best-ever seen solution
    2 -> initial elitism: reinject x0 as long as it is not improved upon
    3 -> initial elitism on restart: restart if best encountered solution is not the the final solution and reinjects the best solution until the population has better fitness, in its majority
- handle_uncertainty: Enables the handle of uncertainty for the function to optimize, it's based on this paper: https://hal.inria.fr/file/index/docid/276216/filename/TEC2008.pdf
- verbose: Enables debug mode for CMA-ES.