### PR TITLE
Scale sigma in CMA-ES

### DIFF
--- a/src/limbo/opt/cmaes.hpp
+++ b/src/limbo/opt/cmaes.hpp
@@ -181,8 +181,7 @@ namespace limbo {
                 }
                 GenoPheno<pwqBoundStrategy> gp(lbounds, ubounds, dim);
                 // initial step-size, i.e. estimated initial parameter error.
-                // we suppose we are optimizing on [0, 1], but we have no idea where to start
-                double sigma = 0.5;
+                double sigma = 0.5 * std::abs(Params::opt_cmaes::ubound() - Params::opt_cmaes::lbound());
                 std::vector<double> x0(init.data(), init.data() + init.size());
                 // -1 for automatically decided lambda, 0 is for random seeding of the internal generator.
                 CMAParameters<GenoPheno<pwqBoundStrategy>> cmaparams(dim, &x0.front(), sigma, -1, 0, gp);


### PR DESCRIPTION
I think we should scale the sigma in CMA-ES when the bounds are not in `[0,1]`..