### PR TITLE
Removed forgotten flag for libcmaes

### DIFF
--- a/wscript
+++ b/wscript
@@ -106,7 +106,7 @@ def configure(conf):
 
         if conf.env.CXX_NAME in ["icc", "icpc"]:
             common_flags = "-Wall -std=c++11"
-            opt_flags = " -O3 -xHost  -march=native -mtune=native -unroll -fma -g"
+            opt_flags = " -O3 -xHost -mtune=native -unroll -fma -g"
         else:
             if conf.env.CXX_NAME in ["gcc", "g++"] and int(conf.env['CC_VERSION'][0]+conf.env['CC_VERSION'][1]) < 47:
                 common_flags = "-Wall -std=c++0x"


### PR DESCRIPTION
We forgot to correct the bug for the intel compiler also. See #200 ...