### PR TITLE
Adds 2 more parameters to CMA-ES

### DIFF
--- a/src/benchmarks/limbo/bench.cpp
+++ b/src/benchmarks/limbo/bench.cpp
@@ -99,7 +99,7 @@ struct Params {
     };
 #ifdef USE_LIBCMAES
     struct opt_cmaes : public defaults::opt_cmaes {
-        BO_PARAM(double, max_fun_evals, 500);
+        BO_PARAM(int, max_fun_evals, 500);
         BO_PARAM(double, fun_tolerance, 1e-6);
         BO_PARAM(double, xrel_tolerance, 1e-6);
     };

--- a/src/limbo/opt/cmaes.hpp
+++ b/src/limbo/opt/cmaes.hpp
@@ -68,7 +68,7 @@ namespace limbo {
             BO_PARAM(int, restarts, 1);
             /// @ingroup opt_defaults
             /// maximum number of calls to the function to be optimized
-            BO_PARAM(double, max_fun_evals, -1);
+            BO_PARAM(int, max_fun_evals, -1);
             /// @ingroup opt_defaults
             /// threshold based on the difference in value of a fixed number
             /// of trials: if bigger than 0, it enables the tolerance criteria
@@ -112,8 +112,19 @@ namespace limbo {
             /// @ingroup opt_defaults
             /// upper bound (in input) for cmaes
             BO_PARAM(double, ubound, 1.0);
+            /// @ingroup opt_defaults
+            /// if stochastic, the mean of the
+            /// last distribution is returned
+            /// otherwise, the best ever candidate
+            /// is returned. If handle_uncertainty is on,
+            /// this is also enabled.
+            BO_PARAM(bool, stochastic, false);
+            /// @ingroup opt_defaults
+            /// number of parent population
+            /// -1 to automatically determine
+            BO_PARAM(int, lambda, -1);
         };
-    }
+    } // namespace defaults
 
     namespace opt {
         /// @ingroup opt
@@ -127,7 +138,7 @@ namespace limbo {
         ///   - int variant
         ///   - int elitism
         ///   - int restarts
-        ///   - double max_fun_evals
+        ///   - int max_fun_evals
         ///   - double fun_tolerance
         ///   - double xrel_tolerance
         ///   - double fun_target
@@ -136,6 +147,8 @@ namespace limbo {
         ///   - bool verbose
         ///   - double lb (lower bounds)
         ///   - double ub (upper bounds)
+        ///   - bool stochastic
+        ///   - int lambda
         template <typename Params>
         struct Cmaes {
         public:
@@ -167,11 +180,14 @@ namespace limbo {
                 double sigma = 0.5;
                 std::vector<double> x0(init.data(), init.data() + init.size());
 
-                CMAParameters<> cmaparams(x0, sigma);
+                CMAParameters<> cmaparams(x0, sigma, Params::opt_cmaes::lambda());
                 _set_common_params(cmaparams, dim);
 
                 // the optimization itself
                 CMASolutions cmasols = cmaes<>(f_cmaes, cmaparams);
+                if (Params::opt_cmaes::stochastic() || Params::opt_cmaes::handle_uncertainty())
+                    return cmasols.xmean();
+
                 return cmasols.get_best_seen_candidate().get_x_dvec();
             }
 
@@ -192,13 +208,14 @@ namespace limbo {
                 double sigma = 0.5 * std::abs(Params::opt_cmaes::ubound() - Params::opt_cmaes::lbound());
                 std::vector<double> x0(init.data(), init.data() + init.size());
                 // -1 for automatically decided lambda, 0 is for random seeding of the internal generator.
-                CMAParameters<GenoPheno<pwqBoundStrategy>> cmaparams(dim, &x0.front(), sigma, -1, 0, gp);
+                CMAParameters<GenoPheno<pwqBoundStrategy>> cmaparams(dim, &x0.front(), sigma, Params::opt_cmaes::lambda(), 0, gp);
                 _set_common_params(cmaparams, dim);
 
                 // the optimization itself
                 CMASolutions cmasols = cmaes<GenoPheno<pwqBoundStrategy>>(f_cmaes, cmaparams);
-                //cmasols.print(std::cout, 1, gp);
-                //to_f_representation
+                if (Params::opt_cmaes::stochastic() || Params::opt_cmaes::handle_uncertainty())
+                    return gp.pheno(cmasols.xmean());
+
                 return gp.pheno(cmasols.get_best_seen_candidate().get_x_dvec());
             }
 
@@ -259,7 +276,7 @@ namespace limbo {
                 cmaparams.set_quiet(!Params::opt_cmaes::verbose());
             }
         };
-    }
-}
+    } // namespace opt
+} // namespace limbo
 #endif
 #endif


### PR DESCRIPTION
A few more parameters for CMA-ES that are needed for Black-DROPS:

- **lambda** (int): control the initial population, automatically determined if -1
- **stochastic** (bool): if this is on, the mean of the last distribution is returned; otherwise, the best ever candidate is returned. If *handle_uncertainty* is on, this is also enabled.