### PR TITLE
Fix GP sigma prediction

### DIFF
--- a/src/limbo/model/gp.hpp
+++ b/src/limbo/model/gp.hpp
@@ -160,15 +160,15 @@ namespace limbo {
             {
                 if (_samples.size() == 0)
                     return std::make_tuple(_mean_function(v, *this),
-                        _kernel_function(v, v));
+                        _kernel_function(v, v) + _kernel_function.noise());
 
                 Eigen::VectorXd k = _compute_k(v);
-                return std::make_tuple(_mu(v, k), _sigma(v, k));
+                return std::make_tuple(_mu(v, k), _sigma(v, k) + _kernel_function.noise());
             }
 
             /**
              \\rst
-             return :math:`\mu` (unormalized). If there is no sample, return the value according to the mean function.
+             return :math:`\mu` (un-normalized). If there is no sample, return the value according to the mean function.
              \\endrst
             */
             Eigen::VectorXd mu(const Eigen::VectorXd& v) const
@@ -180,14 +180,14 @@ namespace limbo {
 
             /**
              \\rst
-             return :math:`\sigma^2` (unormalized). If there is no sample, return the max :math:`\sigma^2`.
+             return :math:`\sigma^2` (un-normalized). If there is no sample, return the max :math:`\sigma^2`.
              \\endrst
             */
             double sigma(const Eigen::VectorXd& v) const
             {
                 if (_samples.size() == 0)
-                    return _kernel_function(v, v);
-                return _sigma(v, _compute_k(v));
+                    return _kernel_function(v, v) + _kernel_function.noise();
+                return _sigma(v, _compute_k(v)) + _kernel_function.noise();
             }
 
             /// return the number of dimensions of the input

--- a/src/tests/test_gp.cpp
+++ b/src/tests/test_gp.cpp
@@ -474,7 +474,7 @@ BOOST_AUTO_TEST_CASE(test_gp_dim)
     BOOST_CHECK(std::abs((mu(0) - 5)) < 1);
     BOOST_CHECK(std::abs((mu(1) - 5)) < 1);
 
-    BOOST_CHECK(sigma <= Params::kernel::noise() + 1e-8);
+    BOOST_CHECK(sigma <= 2. * (Params::kernel::noise() + 1e-8));
 }
 
 BOOST_AUTO_TEST_CASE(test_gp)
@@ -496,15 +496,15 @@ BOOST_AUTO_TEST_CASE(test_gp)
     double sigma;
     std::tie(mu, sigma) = gp.query(make_v1(1));
     BOOST_CHECK(std::abs((mu(0) - 5)) < 1);
-    BOOST_CHECK(sigma <= Params::kernel::noise() + 1e-8);
+    BOOST_CHECK(sigma <= 2. * (Params::kernel::noise() + 1e-8));
 
     std::tie(mu, sigma) = gp.query(make_v1(2));
     BOOST_CHECK(std::abs((mu(0) - 10)) < 1);
-    BOOST_CHECK(sigma <= Params::kernel::noise() + 1e-8);
+    BOOST_CHECK(sigma <= 2. * (Params::kernel::noise() + 1e-8));
 
     std::tie(mu, sigma) = gp.query(make_v1(3));
     BOOST_CHECK(std::abs((mu(0) - 5)) < 1);
-    BOOST_CHECK(sigma <= Params::kernel::noise() + 1e-8);
+    BOOST_CHECK(sigma <= 2. * (Params::kernel::noise() + 1e-8));
 
     for (double x = 0; x < 4; x += 0.05) {
         Eigen::VectorXd mu;
@@ -690,15 +690,15 @@ BOOST_AUTO_TEST_CASE(test_gp_auto)
     double sigma;
     std::tie(mu, sigma) = gp.query(make_v1(1));
     BOOST_CHECK(std::abs((mu(0) - 5)) < 1);
-    BOOST_CHECK(sigma <= gp.kernel_function().noise() + 1e-8);
+    BOOST_CHECK(sigma <= 2. * (gp.kernel_function().noise() + 1e-8));
 
     std::tie(mu, sigma) = gp.query(make_v1(2));
     BOOST_CHECK(std::abs((mu(0) - 10)) < 1);
-    BOOST_CHECK(sigma <= gp.kernel_function().noise() + 1e-8);
+    BOOST_CHECK(sigma <= 2. * (gp.kernel_function().noise() + 1e-8));
 
     std::tie(mu, sigma) = gp.query(make_v1(3));
     BOOST_CHECK(std::abs((mu(0) - 5)) < 1);
-    BOOST_CHECK(sigma <= gp.kernel_function().noise() + 1e-8);
+    BOOST_CHECK(sigma <= 2. * (gp.kernel_function().noise() + 1e-8));
 }
 
 BOOST_AUTO_TEST_CASE(test_gp_init_variance)


### PR DESCRIPTION
We were forgetting to add the noise in the sigma prediction in the GPs.. This is a **quite** serious bug. We should merge soon. @jbmouret @Aneoshun I would like your review as soon as possible..