### PR TITLE
Provide more configurable random generator

### DIFF
--- a/src/limbo/tools/random_generator.hpp
+++ b/src/limbo/tools/random_generator.hpp
@@ -69,11 +69,21 @@ namespace limbo {
         class RandomGenerator {
         public:
             using result_type = typename D::result_type;
-            RandomGenerator(result_type a, result_type b) : _dist(a, b), _rgen(randutils::auto_seed_128{}.base()) {}
-            result_type rand()
+            RandomGenerator(result_type a, result_type b, int seed = -1) : _dist(a, b) { this->seed(seed); }
+
+            result_type rand() { return _dist(_rgen); }
+
+            void seed(int seed = -1)
             {
-                return _dist(_rgen);
+                if (seed >= 0)
+                    _rgen.seed(seed);
+                else
+                    _rgen.seed(randutils::auto_seed_128{}.base());
             }
+
+            void reset() { _dist.reset(); }
+
+            void param(const typename D::param_type& param) { _dist.param(param); }
 
         private:
             D _dist;
@@ -95,36 +105,41 @@ namespace limbo {
         /// Double random number generator (gaussian)
         using rgen_gauss_t = RandomGenerator<rdist_gauss_t>;
 
-        ///@ingroup tools
-        ///integer random number generator
+        /// @ingroup tools
+        /// integer random number generator
         using rgen_int_t = RandomGenerator<rdist_int_t>;
 
         /// @ingroup tools
-        /// random vector in [0, 1.0]
+        /// random vector by providing custom RandomGenerator
+        template <typename Rng>
+        inline Eigen::VectorXd random_vec(int size, Rng& rng)
+        {
+            Eigen::VectorXd res(size);
+            for (int i = 0; i < size; ++i)
+                res[i] = rng.rand();
+            return res;
+        }
+
+        /// @ingroup tools
+        /// random vector in [0, 1]
         ///
         /// - this function is thread safe because we use a random generator for each thread
         /// - we use a C++11 random number generator
         inline Eigen::VectorXd random_vector_bounded(int size)
         {
             static thread_local rgen_double_t rgen(0.0, 1.0);
-            Eigen::VectorXd res(size);
-            for (int i = 0; i < size; ++i)
-                res[i] = rgen.rand();
-            return res;
+            return random_vec(size, rgen);
         }
 
         /// @ingroup tools
-        /// random vector generated with a normal distribution centered on 0, with standard deviation of 10.0
+        /// random vector generated with a normal distribution centered on 0, with standard deviation of 10
         ///
         /// - this function is thread safe because we use a random generator for each thread
         /// - we use a C++11 random number generator
         inline Eigen::VectorXd random_vector_unbounded(int size)
         {
             static thread_local rgen_gauss_t rgen(0.0, 10.0);
-            Eigen::VectorXd res(size);
-            for (int i = 0; i < size; ++i)
-                res[i] = rgen.rand();
-            return res;
+            return random_vec(size, rgen);
         }
 
         /// @ingroup tools


### PR DESCRIPTION
I had a need for changing seeds, params and resetting the random generator (and/or the underlying distribution). I provide a small fix that does not change the API at all, but gives more flexibility to someone that wants it. Btw, we could discuss a way of providing it throughout limbo; i.e., in our optimizers, initiliazers etc. I will open an issue about this..