### PR TITLE
Expose all (or most of) libcmaes stopping criteria parameters

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -76,5 +76,5 @@ install:
 
 # Change this to your needs
 script:
-  - if [ "$SFERES" = "OFF" ]; then $PYTHON ./waf configure $LAPACKE ; else $PYTHON ./waf configure --sferes=$CI_HOME/sferes2 ; fi
+  - if [ "$SFERES" = "OFF" ]; then $PYTHON ./waf configure --nowarnings $LAPACKE ; else $PYTHON ./waf configure --sferes=$CI_HOME/sferes2 --nowarnings ; fi
   - if [ "$EXPERIMENTAL" = "OFF" ]; then $PYTHON ./waf --tests --alltests -v ; else $PYTHON ./waf --experimental ; fi

--- a/ci/install_libcmaes.sh
+++ b/ci/install_libcmaes.sh
@@ -10,8 +10,8 @@ cd libcmaes
 git checkout fix_flags_native
 mkdir build
 cd build
-cmake -DUSE_TBB=ON -DUSE_OPENMP=OFF ..
-make
+cmake -DUSE_TBB=ON -DUSE_OPENMP=OFF -DBUILD_PYTHON=OFF -DBUILD_TESTS=OFF -DBUILD_EXAMPLES=OFF -DLINK_PYTHON=OFF ..
+make CXXFLAGS="-w"
 sudo make install
 sudo ldconfig
 cd $CI_HOME

--- a/ci/install_libcmaes.sh
+++ b/ci/install_libcmaes.sh
@@ -10,7 +10,7 @@ cd libcmaes
 git checkout fix_flags_native
 mkdir build
 cd build
-cmake -DUSE_TBB=ON -DUSE_OPENMP=OFF -DBUILD_PYTHON=OFF -DBUILD_TESTS=OFF -DBUILD_EXAMPLES=OFF -DLINK_PYTHON=OFF ..
+cmake -E env CXXFLAGS="-w" cmake -DUSE_TBB=ON -DUSE_OPENMP=OFF -DBUILD_PYTHON=OFF -DBUILD_TESTS=OFF -DBUILD_EXAMPLES=OFF -DLINK_PYTHON=OFF ..
 make CXXFLAGS="-w"
 sudo make install
 sudo ldconfig

--- a/src/limbo/opt/cmaes.hpp
+++ b/src/limbo/opt/cmaes.hpp
@@ -70,6 +70,17 @@ namespace limbo {
             /// maximum number of calls to the function to be optimized
             BO_PARAM(int, max_fun_evals, -1);
             /// @ingroup opt_defaults
+            /// maximum number of iterations to be optimized
+            BO_PARAM(int, max_iters, -1);
+            /// @ingroup opt_defaults
+            /// enable/disable automatic max iterations
+            BO_PARAM(bool, auto_max_iters, true);
+            /// @ingroup opt_defaults
+            /// enable/disable stopping if getting the same function value repeatedly
+            BO_PARAM(bool, equal_fun_evals, true);
+            /// @ingroup opt_defaults
+            BO_PARAM(bool, stagnation, true);
+            /// @ingroup opt_defaults
             /// threshold based on the difference in value of a fixed number
             /// of trials: if bigger than 0, it enables the tolerance criteria
             /// for stopping based in the history of rewards.
@@ -139,6 +150,10 @@ namespace limbo {
         ///   - int elitism
         ///   - int restarts
         ///   - int max_fun_evals
+        ///   - int max_iters
+        ///   - bool auto_max_iters
+        ///   - bool equal_fun_evals
+        ///   - bool stagnation
         ///   - double fun_tolerance
         ///   - double xrel_tolerance
         ///   - double fun_target
@@ -267,17 +282,24 @@ namespace limbo {
                     ? (900.0 * (dim + 3.0) * (dim + 3.0))
                     : Params::opt_cmaes::max_fun_evals();
                 cmaparams.set_max_fevals(max_evals);
-                // max iteration is here only for security
-                cmaparams.set_max_iter(100000);
+                cmaparams.set_stopping_criteria(MAXFEVALS, true);
+
+                // if no max iters provided, we put a safety limit (to not take forever)
+                size_t max_iters = Params::opt_cmaes::max_iters() < 0
+                    ? 1000000
+                    : Params::opt_cmaes::max_iters();
+                cmaparams.set_max_iter(max_iters);
+                cmaparams.set_stopping_criteria(MAXITER, true);
+
+                // enable/disable automatic max iterations
+                cmaparams.set_stopping_criteria(AUTOMAXITER, Params::opt_cmaes::auto_max_iters());
 
                 if (Params::opt_cmaes::fun_tolerance() < 0) {
-                    // we do not know if what is the actual maximum / minimum of the function
-                    // therefore we deactivate this stopping criterion
-                    cmaparams.set_stopping_criteria(FTARGET, false);
+                    cmaparams.set_stopping_criteria(TOLHISTFUN, false);
                 }
                 else {
                     // the FTARGET criteria also allows us to enable ftolerance
-                    cmaparams.set_stopping_criteria(FTARGET, true);
+                    cmaparams.set_stopping_criteria(TOLHISTFUN, true);
                     cmaparams.set_ftolerance(Params::opt_cmaes::fun_tolerance());
                 }
 
@@ -286,18 +308,34 @@ namespace limbo {
                     cmaparams.set_stopping_criteria(FTARGET, true);
                     cmaparams.set_ftarget(-Params::opt_cmaes::fun_target());
                 }
+                else {
+                    // we do not know what is the actual maximum / minimum of the function
+                    // therefore we deactivate this stopping criterion
+                    cmaparams.set_stopping_criteria(FTARGET, false);
+                }
 
-                // enable stopping criteria by several equalfunvals and maxfevals
-                cmaparams.set_stopping_criteria(EQUALFUNVALS, true);
-                cmaparams.set_stopping_criteria(MAXFEVALS, true);
+                // enable stopping criteria by several equalfunvals
+                cmaparams.set_stopping_criteria(EQUALFUNVALS, Params::opt_cmaes::equal_fun_evals());
 
                 // enable additional criteria to stop
-                cmaparams.set_stopping_criteria(TOLX, true);
                 // set different tolerance if available
                 if (Params::opt_cmaes::xrel_tolerance() > 0) {
+                    cmaparams.set_stopping_criteria(TOLX, true);
                     cmaparams.set_xtolerance(Params::opt_cmaes::xrel_tolerance());
                 }
+                else {
+                    cmaparams.set_stopping_criteria(TOLX, false);
+                }
+
+                // enable stopping criteria because of mal-conditions
                 cmaparams.set_stopping_criteria(CONDITIONCOV, true);
+                cmaparams.set_stopping_criteria(TOLUPSIGMA, true);
+
+                // disable stopping criteria for partial success
+                cmaparams.set_stopping_criteria(NOEFFECTAXIS, false);
+                cmaparams.set_stopping_criteria(NOEFFECTCOOR, false);
+
+                cmaparams.set_stopping_criteria(STAGNATION, Params::opt_cmaes::stagnation());
 
                 // enable or disable different parameters
                 cmaparams.set_initial_fvalue(Params::opt_cmaes::fun_compute_initial());

--- a/wscript
+++ b/wscript
@@ -91,6 +91,7 @@ def options(opt):
         opt.add_option('--cpp14', action='store_true', default=False, help='force c++-14 compilation [--cpp14]', dest='cpp14')
         opt.add_option('--no-native', action='store_true', default=False, help='disable -march=native, which can cause some troubles [--no-native]', dest='no_native')
         opt.add_option('--openmp', action='store_true', default=False, help='enable OpenMP (if found)', dest='openmp')
+        opt.add_option('--nowarnings', action='store_true', default=False, help='disable all warnings (used by the CI)', dest='nowarnings')
 
 
         try:
@@ -141,7 +142,7 @@ def configure(conf):
         conf.env.LIBRARIES = 'BOOST EIGEN TBB LIBCMAES NLOPT'
         if conf.options.openmp:
             conf.env.LIBRARIES = conf.env.LIBRARIES + ' OMP'
-        
+
         # compiler
         is_cpp14 = conf.options.cpp14
         if is_cpp14:
@@ -167,7 +168,7 @@ def configure(conf):
 
         # is libcmaes compiled with -march=native (avx instructions)?
         cmaes_native = True
-        if conf.env.DEFINES_LIBCMAES: # if we have CMA-ES activated & found 
+        if conf.env.DEFINES_LIBCMAES: # if we have CMA-ES activated & found
             conf.start_msg('Checking for libcmaes AVX support (-march=native)')
             cmaes_native = conf.check_avx('libcmaes', 'cmaes')
             if cmaes_native:
@@ -185,6 +186,9 @@ def configure(conf):
 
         all_flags = common_flags + opt_flags
         conf.env['CXXFLAGS'] = conf.env['CXXFLAGS'] + all_flags.split(' ')
+
+        if conf.options.nowarnings:
+            conf.env['CXXFLAGS'] = conf.env['CXXFLAGS'] + ['-w']
         Logs.pprint('NORMAL', 'CXXFLAGS: %s' % (conf.env['CXXFLAGS'] + conf.env['CXXFLAGS_OMP']))
 
         if conf.options.exp:


### PR DESCRIPTION
This PR attempts to solve #306 to expose all (or most of) libcmaes stopping criteria parameters. It also fixes a small bug in setting one of them.