### PR TITLE
Allow Limbo to work on windows.

### DIFF
--- a/src/limbo/bayes_opt/bo_base.hpp
+++ b/src/limbo/bayes_opt/bo_base.hpp
@@ -63,6 +63,7 @@
 #include <Eigen/Core>
 
 // we need everything to have the defaults
+#define _USE_MATH_DEFINES // This makes sure to bring in the M_PI define which is not in the C or C++ standard and is not defined by default on Windows.
 #include <limbo/acqui/ucb.hpp>
 #include <limbo/init/random_sampling.hpp>
 #include <limbo/kernel/exp.hpp>

--- a/src/limbo/model/gp.hpp
+++ b/src/limbo/model/gp.hpp
@@ -46,10 +46,6 @@
 #ifndef LIMBO_MODEL_GP_HPP
 #define LIMBO_MODEL_GP_HPP
 
-#ifdef _WIN32
-#include <corecrt_math_defines.h> // This brings in the M_PI define which is not in the C or C++ standard.
-#endif
-
 #include <cassert>
 #include <iostream>
 #include <limits>

--- a/src/limbo/model/gp.hpp
+++ b/src/limbo/model/gp.hpp
@@ -46,6 +46,10 @@
 #ifndef LIMBO_MODEL_GP_HPP
 #define LIMBO_MODEL_GP_HPP
 
+#ifdef _WIN32
+#include <corecrt_math_defines.h> // This brings in the M_PI define which is not in the C or C++ standard.
+#endif
+
 #include <cassert>
 #include <iostream>
 #include <limits>

--- a/src/limbo/tools/sys.hpp
+++ b/src/limbo/tools/sys.hpp
@@ -49,7 +49,11 @@
 
 #include <ctime>
 #include <string>
+#ifdef _WIN32
+#include <windows.h>
+#else
 #include <unistd.h>
+#endif
 
 namespace limbo {
     namespace tools {
@@ -69,7 +73,12 @@ namespace limbo {
         inline std::string hostname()
         {
             char hostname[50];
+#ifdef _WIN32
+            DWORD buffCharCount = 50;
+            int res = GetComputerNameA(hostname, &buffCharCount);
+#else
             int res = gethostname(hostname, 50);
+#endif
             assert(res == 0);
             res = 0; // avoid a warning in opt mode
             return std::string(hostname);

--- a/src/limbo/tools/sys.hpp
+++ b/src/limbo/tools/sys.hpp
@@ -75,12 +75,14 @@ namespace limbo {
             char hostname[50];
 #ifdef _WIN32
             DWORD buffCharCount = 50;
-            int res = GetComputerNameA(hostname, &buffCharCount);
+            bool ok = GetComputerNameA(hostname, &buffCharCount);
+            assert(ok);
 #else
             int res = gethostname(hostname, 50);
-#endif
             assert(res == 0);
             res = 0; // avoid a warning in opt mode
+#endif
+           
             return std::string(hostname);
         }
 


### PR DESCRIPTION
This PR makes 2 minor changes to allow Limbo to compile on a Windows machine. These changes are guarded by the `#ifdef _WIN32` preprocessor so they will not affect non-Windows builds.

 - In "limbo/model/gp.hpp" includes "corecrt_math_defines.h" so that the `M_PI` preprocessor define will be defined
 - In "limbo/tools/sys.hpp" "windows.h" is included instead of "unistd.h" and the "GetComputerNameA" function is used instead of "unistd.h"'s "gethostname" function.