### PR TITLE
Add missing include for build with MinGW

### DIFF
--- a/src/limbo/tools/sys.hpp
+++ b/src/limbo/tools/sys.hpp
@@ -49,7 +49,6 @@
 
 #include <ctime>
 #include <string>
-#include <unistd.h>
 
 #if defined(__MINGW32__) || defined(_MSC_VER)
 #include <winsock2.h>

--- a/src/limbo/tools/sys.hpp
+++ b/src/limbo/tools/sys.hpp
@@ -51,8 +51,10 @@
 #include <string>
 #include <unistd.h>
 
-#ifdef __MINGW32__
+#if defined(__MINGW32__) || defined(_MSC_VER)
 #include <winsock2.h>
+#else
+#include <unistd.h>
 #endif
 
 namespace limbo {

--- a/src/limbo/tools/sys.hpp
+++ b/src/limbo/tools/sys.hpp
@@ -51,6 +51,10 @@
 #include <string>
 #include <unistd.h>
 
+#ifdef __MINGW32__
+#include <winsock2.h>
+#endif
+
 namespace limbo {
     namespace tools {
         /// @ingroup tools


### PR DESCRIPTION
Hi,

When I tried building a program using Limbo with MinGW (a Windows port of GCC), I got the following error.

```
C:/Users/chris/Programming/C++/Correrender/third_party/limbo/src/limbo/tools/sys.hpp:72:23: error: gethostname' was not declared in this scope; did you mean 'hostname'?
   72 |             int res = gethostname(hostname, 50);
      |                       ^~~~~~~~~~~
      |                       hostname
```

This PR adds an include to winsock2.h when using MinGW, which seems to contain the function declaration of `gethostname` for MinGW. I can confirm that the build then runs without any further compiler errors.
