### PR TITLE
Enable catkin compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,45 @@
+cmake_minimum_required (VERSION 3.9)
+
+project(limbo)
+
+# Default to C99
+if(NOT CMAKE_C_STANDARD)
+  	set(CMAKE_C_STANDARD 99)
+endif()
+
+# Default to C++14
+if(NOT CMAKE_CXX_STANDARD)
+  	set(CMAKE_CXX_STANDARD 14)
+endif()
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  	add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+file(GLOB headers src/limbo/*.hpp)
+
+find_package(Eigen3 REQUIRED)
+
+set(Boost_USE_STATIC_LIBS OFF)
+set(Boost_USE_MULTITHREADED ON)
+set(Boost_USE_STATIC_RUNTIME OFF)
+find_package(Boost 1.45.0 REQUIRED COMPONENTS system filesystem thread unit_test_framework)
+
+if(Boost_FOUND)
+  include_directories(${Boost_INCLUDE_DIRS})
+endif()
+
+# add the binary tree to the search path for include files
+# so that we will find TutoriConfig.h
+include_directories(src/)
+
+add_library(${PROJECT_NAME} INTERFACE)
+
+install(DIRECTORY src/
+  	DESTINATION include)
+
+install(TARGETS ${PROJECT_NAME}
+  	ARCHIVE DESTINATION lib
+  	LIBRARY DESTINATION lib
+  	RUNTIME DESTINATION bin
+)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,50 +4,13 @@ project(limbo VERSION 2.1 DESCRIPTION "limbo LIbrary for Model-Based Optimizatio
 # Cpp standard
 set(CMAKE_CXX_STANDARD 14)
 
-# # Compiler options
-# add_compile_options(-Wall -Wextra -Wpedantic)
-
-# # Dependencies
-# # Eigen
-# find_package(Eigen3 REQUIRED)
-
-# # Boost
-# set(Boost_USE_STATIC_LIBS OFF)
-# set(Boost_USE_MULTITHREADED ON)
-# set(Boost_USE_STATIC_RUNTIME OFF)
-# find_package(Boost 1.45.0 REQUIRED COMPONENTS system filesystem thread unit_test_framework)
-# if(Boost_FOUND)
-#   include_directories(${Boost_INCLUDE_DIRS})
-# endif()
-
-# # TBB
-# find_package(TBB REQUIRED)
-
-# # # NLOpt
-# find_package(NLopt REQUIRED)
-# if(NLopt_FOUND)
-#   include_directories(${NLOPT_INCLUDE_DIRS})
-#   add_definitions(-DUSE_NLOPT)
-# endif()
-
 # # Add library
-# add_library(limbo INTERFACE IMPORTED GLOBAL) # Interface because it's header only
-
-include(ExternalProject)
-ExternalProject_Add(limbo_src
-  SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}
-  CONFIGURE_COMMAND cd ${CMAKE_CURRENT_SOURCE_DIR} && ./waf configure
-  BUILD_COMMAND     cd ${CMAKE_CURRENT_SOURCE_DIR} && ./waf build
-  INSTALL_COMMAND ""
-)
+# Interface because it's header only
+add_library(limbo INTERFACE IMPORTED GLOBAL)
 
 # Install
 include(GNUInstallDirs)
-# Install binaries
-install(
-  FILES ${CMAKE_CURRENT_SOURCE_DIR}/build/src/liblimbo.a
-  DESTINATION ${CMAKE_INSTALL_LIBDIR}
-)
+
 # Install headers
 install(DIRECTORY
           ${CMAKE_CURRENT_SOURCE_DIR}/src/limbo

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,45 +1,77 @@
-cmake_minimum_required (VERSION 3.9)
+cmake_minimum_required (VERSION 3.0.2)
+project(limbo VERSION 2.1 DESCRIPTION "limbo LIbrary for Model-Based Optimization")
 
-project(limbo)
+# Cpp standard
+set(CMAKE_CXX_STANDARD 14)
 
-# Default to C99
-if(NOT CMAKE_C_STANDARD)
-  	set(CMAKE_C_STANDARD 99)
-endif()
+# # Compiler options
+# add_compile_options(-Wall -Wextra -Wpedantic)
 
-# Default to C++14
-if(NOT CMAKE_CXX_STANDARD)
-  	set(CMAKE_CXX_STANDARD 14)
-endif()
+# # Dependencies
+# # Eigen
+# find_package(Eigen3 REQUIRED)
 
-if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  	add_compile_options(-Wall -Wextra -Wpedantic)
-endif()
+# # Boost
+# set(Boost_USE_STATIC_LIBS OFF)
+# set(Boost_USE_MULTITHREADED ON)
+# set(Boost_USE_STATIC_RUNTIME OFF)
+# find_package(Boost 1.45.0 REQUIRED COMPONENTS system filesystem thread unit_test_framework)
+# if(Boost_FOUND)
+#   include_directories(${Boost_INCLUDE_DIRS})
+# endif()
 
-file(GLOB headers src/limbo/*.hpp)
+# # TBB
+# find_package(TBB REQUIRED)
 
-find_package(Eigen3 REQUIRED)
+# # # NLOpt
+# find_package(NLopt REQUIRED)
+# if(NLopt_FOUND)
+#   include_directories(${NLOPT_INCLUDE_DIRS})
+#   add_definitions(-DUSE_NLOPT)
+# endif()
 
-set(Boost_USE_STATIC_LIBS OFF)
-set(Boost_USE_MULTITHREADED ON)
-set(Boost_USE_STATIC_RUNTIME OFF)
-find_package(Boost 1.45.0 REQUIRED COMPONENTS system filesystem thread unit_test_framework)
+# # Add library
+# add_library(limbo INTERFACE IMPORTED GLOBAL) # Interface because it's header only
 
-if(Boost_FOUND)
-  include_directories(${Boost_INCLUDE_DIRS})
-endif()
-
-# add the binary tree to the search path for include files
-# so that we will find TutoriConfig.h
-include_directories(src/)
-
-add_library(${PROJECT_NAME} INTERFACE)
-
-install(DIRECTORY src/
-  	DESTINATION include)
-
-install(TARGETS ${PROJECT_NAME}
-  	ARCHIVE DESTINATION lib
-  	LIBRARY DESTINATION lib
-  	RUNTIME DESTINATION bin
+include(ExternalProject)
+ExternalProject_Add(limbo_src
+  SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}
+  CONFIGURE_COMMAND cd ${CMAKE_CURRENT_SOURCE_DIR} && ./waf configure
+  BUILD_COMMAND     cd ${CMAKE_CURRENT_SOURCE_DIR} && ./waf build
+  INSTALL_COMMAND ""
 )
+
+# Install
+include(GNUInstallDirs)
+# Install binaries
+install(
+  FILES ${CMAKE_CURRENT_SOURCE_DIR}/build/src/liblimbo.a
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}
+)
+# Install headers
+install(DIRECTORY
+          ${CMAKE_CURRENT_SOURCE_DIR}/src/limbo
+          ${CMAKE_CURRENT_SOURCE_DIR}/src/external
+          ${CMAKE_CURRENT_SOURCE_DIR}/src/hv
+          ${CMAKE_CURRENT_SOURCE_DIR}/src/ehvi
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+        )
+
+# Export
+include(CMakePackageConfigHelpers)
+set(INCLUDE_INSTALL_DIR ${CMAKE_INSTALL_INCLUDEDIR})
+set(LIB_INSTALL_DIR ${CMAKE_INSTALL_LIBDIR})
+
+configure_package_config_file(cmake/limboConfig.cmake.in
+  ${CMAKE_CURRENT_BINARY_DIR}/limboConfig.cmake
+  INSTALL_DESTINATION ${LIB_INSTALL_DIR}/limbo/cmake
+  PATH_VARS INCLUDE_INSTALL_DIR LIB_INSTALL_DIR)
+
+write_basic_package_version_file(
+  ${CMAKE_CURRENT_BINARY_DIR}/limboConfigVersion.cmake
+  VERSION 0.0.0
+  COMPATIBILITY SameMajorVersion)
+
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/limboConfig.cmake
+              ${CMAKE_CURRENT_BINARY_DIR}/limboConfigVersion.cmake
+        DESTINATION ${LIB_INSTALL_DIR}/limbo/cmake )

--- a/cmake/limboConfig.cmake.in
+++ b/cmake/limboConfig.cmake.in
@@ -8,21 +8,31 @@ set_and_check(limbo_LIB_DIR "@PACKAGE_LIB_INSTALL_DIR@")
 
 check_required_components(Eigen)
 check_required_components(Boost)
+check_required_components(Tbb)
+check_required_components(NLopt)
 
+# Compiler options
+# add_compile_options(-Wall)
+
+# Dependencies
+# Eigen
 find_package(Eigen3 REQUIRED)
-find_package(Boost REQUIRED)
-# find_package(TBB REQUIRED)
-# find_package(NLopt REQUIRED)
 
-# add_library(_limbo INTERFACE)
-# set_target_properties(_limbo PROPERTIES
-#   INTERFACE_INCLUDE_DIRECTORIES ${limbo_INCLUDE_DIR}
-# )
+# Boost
+set(Boost_USE_STATIC_LIBS OFF)
+set(Boost_USE_MULTITHREADED ON)
+set(Boost_USE_STATIC_RUNTIME OFF)
+find_package(Boost 1.45.0 REQUIRED COMPONENTS system filesystem thread unit_test_framework)
+if(Boost_FOUND)
+  include_directories(${Boost_INCLUDE_DIRS})
+endif()
 
-add_library(_limbo STATIC IMPORTED GLOBAL)
-set_target_properties(_limbo PROPERTIES
-  IMPORTED_LOCATION ${limbo_LIB_DIR}/liblimbo.a
-  INTERFACE_INCLUDE_DIRECTORIES ${limbo_INCLUDE_DIR}
-)
-target_link_libraries(_limbo INTERFACE Eigen Boost)
-add_library(limbo::limbo ALIAS _limbo)
+# TBB
+find_package(TBB REQUIRED)
+
+# # NLOpt
+find_package(NLopt REQUIRED)
+if(NLopt_FOUND)
+  include_directories(${NLOPT_INCLUDE_DIRS})
+  add_definitions(-DUSE_NLOPT)
+endif()

--- a/cmake/limboConfig.cmake.in
+++ b/cmake/limboConfig.cmake.in
@@ -8,8 +8,6 @@ set_and_check(limbo_LIB_DIR "@PACKAGE_LIB_INSTALL_DIR@")
 
 check_required_components(Eigen)
 check_required_components(Boost)
-check_required_components(Tbb)
-check_required_components(NLopt)
 
 # Compiler options
 # add_compile_options(-Wall)
@@ -28,10 +26,14 @@ if(Boost_FOUND)
 endif()
 
 # TBB
-find_package(TBB REQUIRED)
+find_package(TBB)
+if(TBB_FOUND)
+  include_directories(${TBB_INCLUDE_DIRS})
+  add_definitions(-DUSE_TBB)
+endif()
 
 # # NLOpt
-find_package(NLopt REQUIRED)
+find_package(NLopt)
 if(NLopt_FOUND)
   include_directories(${NLOPT_INCLUDE_DIRS})
   add_definitions(-DUSE_NLOPT)

--- a/cmake/limboConfig.cmake.in
+++ b/cmake/limboConfig.cmake.in
@@ -1,0 +1,28 @@
+set(limbo_VERSION 0.0.0)
+
+@PACKAGE_INIT@
+
+set_and_check(limbo_INCLUDE_DIR "@PACKAGE_INCLUDE_INSTALL_DIR@")
+set_and_check(limbo_INCLUDE_DIRS "@PACKAGE_INCLUDE_INSTALL_DIR@")
+set_and_check(limbo_LIB_DIR "@PACKAGE_LIB_INSTALL_DIR@")
+
+check_required_components(Eigen)
+check_required_components(Boost)
+
+find_package(Eigen3 REQUIRED)
+find_package(Boost REQUIRED)
+# find_package(TBB REQUIRED)
+# find_package(NLopt REQUIRED)
+
+# add_library(_limbo INTERFACE)
+# set_target_properties(_limbo PROPERTIES
+#   INTERFACE_INCLUDE_DIRECTORIES ${limbo_INCLUDE_DIR}
+# )
+
+add_library(_limbo STATIC IMPORTED GLOBAL)
+set_target_properties(_limbo PROPERTIES
+  IMPORTED_LOCATION ${limbo_LIB_DIR}/liblimbo.a
+  INTERFACE_INCLUDE_DIRECTORIES ${limbo_INCLUDE_DIR}
+)
+target_link_libraries(_limbo INTERFACE Eigen Boost)
+add_library(limbo::limbo ALIAS _limbo)

--- a/package.xml
+++ b/package.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>limbo</name>
+  <version>2.1.0</version>
+  <description>A lightweight framework for Gaussian processes and Bayesian optimization of black-box functions (C++-11)</description>
+
+  <author>Antoine Cully</author>
+  <author>Jean Baptiste Mouret</author>
+  <author>Konstantinos Chatzilygeroudis</author>
+  <author>Federico Allocati</author>
+
+  <maintainer email="jean-baptiste.mouret@inria.fr">Jean Baptiste Mouret</maintainer>
+  <license>CeCILL-C</license>
+
+  <buildtool_depend>cmake</buildtool_depend>
+
+  <build_depend>boost</build_depend>
+  <build_depend>eigen</build_depend>
+  <build_depend>tbb</build_depend>
+
+  <export>
+    <!-- Specify that this is not really a Catkin package-->
+    <build_type>cmake</build_type>
+  </export>
+</package>

--- a/package.xml
+++ b/package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package format="2">
+<package format="3">
   <name>limbo</name>
   <version>2.1.0</version>
   <description>A lightweight framework for Gaussian processes and Bayesian optimization of black-box functions (C++-11)</description>
@@ -17,6 +17,10 @@
   <build_depend>boost</build_depend>
   <build_depend>eigen</build_depend>
   <build_depend>tbb</build_depend>
+
+  <!-- The following tags are recommended by REP-136 -->
+  <exec_depend condition="$ROS_VERSION == 1">catkin</exec_depend>
+  <exec_depend condition="$ROS_VERSION == 2">ament_cmake</exec_depend>
 
   <export>
     <!-- Specify that this is not really a Catkin package-->

--- a/src/limbo/kernel/kernel.hpp
+++ b/src/limbo/kernel/kernel.hpp
@@ -141,6 +141,7 @@ namespace limbo {
             {
                 // This should never be called!
                 assert(false);
+                return Eigen::VectorXd();
             }
         };
     } // namespace kernel

--- a/src/limbo/mean/mean.hpp
+++ b/src/limbo/mean/mean.hpp
@@ -72,6 +72,7 @@ namespace limbo {
             {
                 // This should never be called!
                 assert(false);
+                return Eigen::VectorXd();
             }
         };
     } // namespace mean


### PR DESCRIPTION
This includes Cmake configuration files and `package.xml` to build limbo using catkin. This builds upon the CmakeLists file configured by @buschbapti on his fork. Hopefully this makes it easier for other ROS users.